### PR TITLE
feat: Allow adding/appending to groups when adding nodes or edges

### DIFF
--- a/medmodels/medrecord/builder.py
+++ b/medmodels/medrecord/builder.py
@@ -205,7 +205,7 @@ class MedRecordBuilder:
             edge = edge[0]
 
             if is_edge_tuple(edge):
-                _ = medrecord.add_edge(*edge, group)
+                medrecord.add_edge(*edge, group)
                 continue
 
             if (
@@ -215,7 +215,7 @@ class MedRecordBuilder:
                 or is_polars_edge_dataframe_input(edge)
                 or is_polars_edge_dataframe_input_list(edge)
             ):
-                _ = medrecord.add_edges(edge, group)
+                medrecord.add_edges(edge, group)
 
         for group in self._groups:
             if medrecord.contains_group(group):

--- a/medmodels/medrecord/builder.py
+++ b/medmodels/medrecord/builder.py
@@ -178,46 +178,13 @@ class MedRecordBuilder:
                 continue
 
             group = node[1]
-
-            if not medrecord.contains_group(group):
-                medrecord.add_group(group)
-
             node = node[0]
 
             if is_node_tuple(node):
-                medrecord.add_node(*node)
-                medrecord.add_node_to_group(group, node[0])
+                medrecord.add_node(*node, group)
                 continue
 
-            if is_node_tuple_list(node):
-                medrecord.add_nodes(node)
-                medrecord.add_node_to_group(group, [node[0] for node in node])
-                continue
-
-            if is_pandas_node_dataframe_input(node):
-                medrecord.add_nodes(node)
-                medrecord.add_node_to_group(group, node[0][node[1]].tolist())
-                continue
-
-            if is_polars_node_dataframe_input(node):
-                medrecord.add_nodes(node)
-                medrecord.add_node_to_group(group, node[0][node[1]].to_list())
-                continue
-
-            if is_pandas_node_dataframe_input_list(node):
-                medrecord.add_nodes(node)
-                medrecord.add_node_to_group(
-                    group,
-                    [nodes for node in node for nodes in node[0][node[1]].tolist()],
-                )
-                continue
-
-            if is_polars_node_dataframe_input_list(node):
-                medrecord.add_nodes(node)
-                medrecord.add_node_to_group(
-                    group,
-                    [nodes for node in node for nodes in node[0][node[1]].to_list()],
-                )
+            medrecord.add_nodes(node, group)
 
         for edge in self._edges:
             if is_edge_tuple(edge):
@@ -235,15 +202,10 @@ class MedRecordBuilder:
                 continue
 
             group = edge[1]
-
-            if not medrecord.contains_group(group):
-                medrecord.add_group(group)
-
             edge = edge[0]
 
             if is_edge_tuple(edge):
-                edge_index = medrecord.add_edge(*edge)
-                medrecord.add_edge_to_group(group, edge_index)
+                _ = medrecord.add_edge(*edge, group)
                 continue
 
             if (
@@ -253,8 +215,7 @@ class MedRecordBuilder:
                 or is_polars_edge_dataframe_input(edge)
                 or is_polars_edge_dataframe_input_list(edge)
             ):
-                edge_indices = medrecord.add_edges(edge)
-                medrecord.add_edge_to_group(group, edge_indices)
+                _ = medrecord.add_edges(edge, group)
 
         for group in self._groups:
             if medrecord.contains_group(group):

--- a/medmodels/medrecord/medrecord.py
+++ b/medmodels/medrecord/medrecord.py
@@ -550,10 +550,14 @@ class MedRecord:
             None
         """
         self._medrecord.add_node(node, attributes)
-        if group is not None:
-            if not self.contains_group(group):
-                self.add_group(group)
-            self.add_node_to_group(group, node)
+
+        if group is None:
+            return
+
+        if not self.contains_group(group):
+            self.add_group(group)
+
+        self.add_node_to_group(group, node)
 
     @overload
     def remove_node(self, node: NodeIndex) -> Attributes: ...
@@ -630,10 +634,14 @@ class MedRecord:
             self.add_nodes_polars(nodes, group)
         else:
             self._medrecord.add_nodes(nodes)
-            if group is not None:
-                if not self.contains_group(group):
-                    self.add_group(group)
-                self.add_node_to_group(group, [node[0] for node in nodes])
+
+            if group is None:
+                return
+
+            if not self.contains_group(group):
+                self.add_group(group)
+
+            self.add_node_to_group(group, [node[0] for node in nodes])
 
     def add_nodes_pandas(
         self,
@@ -686,18 +694,20 @@ class MedRecord:
             nodes if isinstance(nodes, list) else [nodes]
         )
 
-        if group is not None:
-            if not self.contains_group(group):
-                self.add_group(group)
+        if group is None:
+            return
 
-            if isinstance(nodes, list):
-                nodes_indices = [
-                    nodes for node in nodes for nodes in node[0][node[1]].to_list()
-                ]
-            else:
-                nodes_indices = nodes[0][nodes[1]].to_list()
+        if not self.contains_group(group):
+            self.add_group(group)
 
-            self.add_node_to_group(group, nodes_indices)
+        if isinstance(nodes, list):
+            node_indices = [
+                nodes for node in nodes for nodes in node[0][node[1]].to_list()
+            ]
+        else:
+            node_indices = nodes[0][nodes[1]].to_list()
+
+        self.add_node_to_group(group, node_indices)
 
     def add_edge(
         self,
@@ -719,10 +729,14 @@ class MedRecord:
             EdgeIndex: The index of the added edge.
         """
         edge_index = self._medrecord.add_edge(source_node, target_node, attributes)
-        if group is not None:
-            if not self.contains_group(group):
-                self.add_group(group)
-            self.add_edge_to_group(group, edge_index)
+
+        if group is None:
+            return edge_index
+
+        if not self.contains_group(group):
+            self.add_group(group)
+
+        self.add_edge_to_group(group, edge_index)
 
         return edge_index
 
@@ -804,10 +818,13 @@ class MedRecord:
         else:
             edge_indices = self._medrecord.add_edges(edges)
 
-            if group is not None:
-                if not self.contains_group(group):
-                    self.add_group(group)
-                self.add_edge_to_group(group, edge_indices)
+            if group is None:
+                return edge_indices
+
+            if not self.contains_group(group):
+                self.add_group(group)
+
+            self.add_edge_to_group(group, edge_indices)
 
             return edge_indices
 
@@ -863,10 +880,14 @@ class MedRecord:
         edge_indices = self._medrecord.add_edges_dataframes(
             edges if isinstance(edges, list) else [edges]
         )
-        if group is not None:
-            if not self.contains_group(group):
-                self.add_group(group)
-            self.add_edge_to_group(group, edge_indices)
+
+        if group is None:
+            return edge_indices
+
+        if not self.contains_group(group):
+            self.add_group(group)
+
+        self.add_edge_to_group(group, edge_indices)
 
         return edge_indices
 

--- a/medmodels/medrecord/medrecord.py
+++ b/medmodels/medrecord/medrecord.py
@@ -533,17 +533,27 @@ class MedRecord:
                 (target_node if isinstance(target_node, list) else [target_node]),
             )
 
-    def add_node(self, node: NodeIndex, attributes: AttributesInput) -> None:
-        """Adds a node with specified attributes to the MedRecord instance.
+    def add_node(
+        self,
+        node: NodeIndex,
+        attributes: AttributesInput,
+        group: Optional[Group] = None,
+    ) -> None:
+        """Adds a node with specified attributes to the MedRecord instance. Optionally adds the node to a group.
 
         Args:
             node (NodeIndex): The index of the node to add.
             attributes (Attributes): A dictionary of the node's attributes.
+            group (Optional[Group]): The name of the group to add the node to, optional.
 
         Returns:
             None
         """
-        return self._medrecord.add_node(node, attributes)
+        self._medrecord.add_node(node, attributes)
+        if group is not None:
+            if not self.contains_group(group):
+                self.add_group(group)
+            self.add_node_to_group(group, node)
 
     @overload
     def remove_node(self, node: NodeIndex) -> Attributes: ...
@@ -591,17 +601,21 @@ class MedRecord:
             PolarsNodeDataFrameInput,
             List[PolarsNodeDataFrameInput],
         ],
+        group: Optional[Group] = None,
     ) -> None:
-        """Adds multiple nodes to the MedRecord from different data formats.
+        """Adds multiple nodes to the MedRecord from different data formats and optionally assigns them to a group.
 
         Accepts a list of tuples, DataFrame(s), or PolarsNodeDataFrameInput(s) to add
         nodes. If a DataFrame or list of DataFrames is used, the add_nodes_pandas method
         is called. If PolarsNodeDataFrameInput(s) are provided, each tuple must include
-        a DataFrame and the index column.
+        a DataFrame and the index column. If a group is specified, the nodes are added
+        to the group.
 
         Args:
             nodes (Union[Sequence[NodeTuple], PandasNodeDataFrameInput, List[PandasNodeDataFrameInput], PolarsNodeDataFrameInput, List[PolarsNodeDataFrameInput]]):
                 Data representing nodes in various formats.
+            group (Optional[Group]): The name of the group to add the nodes to. If not
+                specified, the nodes are added to the MedRecord without a group.
 
         Returns:
             None
@@ -609,71 +623,108 @@ class MedRecord:
         if is_pandas_node_dataframe_input(nodes) or is_pandas_node_dataframe_input_list(
             nodes
         ):
-            return self.add_nodes_pandas(nodes)
+            self.add_nodes_pandas(nodes, group)
         elif is_polars_node_dataframe_input(
             nodes
         ) or is_polars_node_dataframe_input_list(nodes):
-            return self.add_nodes_polars(nodes)
+            self.add_nodes_polars(nodes, group)
         else:
-            return self._medrecord.add_nodes(nodes)
+            self._medrecord.add_nodes(nodes)
+            if group is not None:
+                if not self.contains_group(group):
+                    self.add_group(group)
+                self.add_node_to_group(group, [node[0] for node in nodes])
 
     def add_nodes_pandas(
-        self, nodes: Union[PandasNodeDataFrameInput, List[PandasNodeDataFrameInput]]
+        self,
+        nodes: Union[PandasNodeDataFrameInput, List[PandasNodeDataFrameInput]],
+        group: Optional[Group] = None,
     ) -> None:
-        """Adds nodes to the MedRecord instance from one or more Pandas DataFrames.
+        """Adds nodes to the MedRecord instance from one or more Pandas DataFrames. Optionally assigns them to a group.
 
         This method accepts either a single tuple or a list of tuples, where each tuple
-        consists of a Pandas DataFrame and an index column string.
+        consists of a Pandas DataFrame and an index column string. If a group is
+        specified, the nodes are added to the group.
 
         Args:
             nodes (Union[PandasNodeDataFrameInput, List[PandasNodeDataFrameInput]]):
                 A tuple or list of tuples, each with a DataFrame and index column.
+            group (Optional[Group]): The name of the group to add the nodes to. If not
+                specified, the nodes are added to the MedRecord without a group.
 
         Returns:
             None
         """
-        return self.add_nodes_polars(
+        self.add_nodes_polars(
             [process_nodes_dataframe(nodes_df) for nodes_df in nodes]
             if isinstance(nodes, list)
-            else [process_nodes_dataframe(nodes)]
+            else [process_nodes_dataframe(nodes)],
+            group,
         )
 
     def add_nodes_polars(
-        self, nodes: Union[PolarsNodeDataFrameInput, List[PolarsNodeDataFrameInput]]
+        self,
+        nodes: Union[PolarsNodeDataFrameInput, List[PolarsNodeDataFrameInput]],
+        group: Optional[Group] = None,
     ) -> None:
-        """Adds nodes to the MedRecord instance from one or more Polars DataFrames.
+        """Adds nodes to the MedRecord instance from one or more Polars DataFrames. Optionally assigns them to a group.
 
         This method accepts either a single tuple or a list of tuples, where each tuple
-        consists of a Polars DataFrame and an index column string.
+        consists of a Polars DataFrame and an index column string. If a group is
+        specified, the nodes are added to the group.
 
         Args:
             nodes (Union[PolarsNodeDataFrameInput, List[PolarsNodeDataFrameInput]]):
                 A tuple or list of tuples, each with a DataFrame and index column.
+            group (Optional[Group]): The name of the group to add the nodes to. If not
+                specified, the nodes are added to the MedRecord without a group.
 
         Returns:
             None
         """
-        return self._medrecord.add_nodes_dataframes(
+        self._medrecord.add_nodes_dataframes(
             nodes if isinstance(nodes, list) else [nodes]
         )
+
+        if group is not None:
+            if not self.contains_group(group):
+                self.add_group(group)
+
+            if isinstance(nodes, list):
+                nodes_indices = [
+                    nodes for node in nodes for nodes in node[0][node[1]].to_list()
+                ]
+            else:
+                nodes_indices = nodes[0][nodes[1]].to_list()
+
+            self.add_node_to_group(group, nodes_indices)
 
     def add_edge(
         self,
         source_node: NodeIndex,
         target_node: NodeIndex,
         attributes: AttributesInput,
+        group: Optional[Group] = None,
     ) -> EdgeIndex:
-        """Adds an edge between two specified nodes with given attributes.
+        """Adds an edge between two specified nodes with given attributes. Optionally assigns the edge to a group.
 
         Args:
             source_node (NodeIndex): Index of the source node.
             target_node (NodeIndex): Index of the target node.
             attributes (AttributesInput): Dictionary or mapping of edge attributes.
+            group (Optional[Group]): The name of the group to add the edge to. If not
+                specified, the edge is added to the MedRecord without a group.
 
         Returns:
             EdgeIndex: The index of the added edge.
         """
-        return self._medrecord.add_edge(source_node, target_node, attributes)
+        edge_index = self._medrecord.add_edge(source_node, target_node, attributes)
+        if group is not None:
+            if not self.contains_group(group):
+                self.add_group(group)
+            self.add_edge_to_group(group, edge_index)
+
+        return edge_index
 
     @overload
     def remove_edge(self, edge: EdgeIndex) -> Attributes: ...
@@ -721,18 +772,23 @@ class MedRecord:
             PolarsEdgeDataFrameInput,
             List[PolarsEdgeDataFrameInput],
         ],
+        group: Optional[Group] = None,
     ) -> List[EdgeIndex]:
-        """Adds edges to the MedRecord instance from various data formats.
+        """Adds edges to the MedRecord instance from various data formats. Optionally assigns them to a group.
 
         Accepts lists of tuples, DataFrame(s), or EdgeDataFrameInput(s) to add edges.
         Each tuple must have indices for source and target nodes and a dictionary of
         attributes. If a DataFrame or list of DataFrames is used,
-        the add_edges_dataframe method is invoked.
+        the add_edges_dataframe method is invoked. If PolarsEdgeDataFrameInput(s) are
+        provided, each tuple must include a DataFrame and index columns for source and
+        target nodes. If a group is specified, the edges are added to the group.
 
         Args:
             edges (Union[Sequence[EdgeTuple], PandasEdgeDataFrameInput, List[PolarsEdgeDataFrameInput]]):
                 List[PandasEdgeDataFrameInput], PolarsEdgeDataFrameInput,
                 Data representing edges in several formats.
+            group (Optional[Group]): The name of the group to add the edges to. If not
+                specified, the edges are added to the MedRecord without a group.
 
         Returns:
             List[EdgeIndex]: A list of edge indices that were added.
@@ -740,27 +796,38 @@ class MedRecord:
         if is_pandas_edge_dataframe_input(edges) or is_pandas_edge_dataframe_input_list(
             edges
         ):
-            return self.add_edges_pandas(edges)
+            return self.add_edges_pandas(edges, group)
         elif is_polars_edge_dataframe_input(
             edges
         ) or is_polars_edge_dataframe_input_list(edges):
-            return self.add_edges_polars(edges)
+            return self.add_edges_polars(edges, group)
         else:
-            return self._medrecord.add_edges(edges)
+            edge_indices = self._medrecord.add_edges(edges)
+
+            if group is not None:
+                if not self.contains_group(group):
+                    self.add_group(group)
+                self.add_edge_to_group(group, edge_indices)
+
+            return edge_indices
 
     def add_edges_pandas(
-        self, edges: Union[PandasEdgeDataFrameInput, List[PandasEdgeDataFrameInput]]
+        self,
+        edges: Union[PandasEdgeDataFrameInput, List[PandasEdgeDataFrameInput]],
+        group: Optional[Group] = None,
     ) -> List[EdgeIndex]:
-        """Adds edges to the MedRecord from one or more Pandas DataFrames.
+        """Adds edges to the MedRecord from one or more Pandas DataFrames. Optionally assigns them to a group.
 
         This method accepts either a single PandasEdgeDataFrameInput tuple or a list of
         such tuples, each including a DataFrame and index columns for the source and
-        target nodes.
+        target nodes. If a group is specified, the edges are added to the group.
 
         Args:
             edges (Union[PandasEdgeDataFrameInput, List[PandasEdgeDataFrameInput]]):
                 A tuple or list of tuples, each including a DataFrame and index columns
                 for source and target nodes.
+            group (Optional[Group]): The name of the group to add the edges to. If not
+                specified, the edges are added to the MedRecord without a group.
 
         Returns:
             List[EdgeIndex]: A list of the edge indices added.
@@ -768,30 +835,40 @@ class MedRecord:
         return self.add_edges_polars(
             [process_edges_dataframe(edges_df) for edges_df in edges]
             if isinstance(edges, list)
-            else [process_edges_dataframe(edges)]
+            else [process_edges_dataframe(edges)],
+            group,
         )
 
     def add_edges_polars(
         self,
         edges: Union[PolarsEdgeDataFrameInput, List[PolarsEdgeDataFrameInput]],
+        group: Optional[Group] = None,
     ) -> List[EdgeIndex]:
-        """Adds edges to the MedRecord from one or more Polars DataFrames.
+        """Adds edges to the MedRecord from one or more Polars DataFrames. Optionally assigns them to a group.
 
         This method accepts either a single PolarsEdgeDataFrameInput tuple or a list of
         such tuples, each including a DataFrame and index columns for the source and
-        target nodes.
+        target nodes. If a group is specified, the edges are added to the group.
 
         Args:
             edges (Union[PolarsEdgeDataFrameInput, List[PolarsEdgeDataFrameInput]]):
                 A tuple or list of tuples, each including a DataFrame and index columns
                 for source and target nodes.
+            group (Optional[Group]): The name of the group to add the edges to. If not
+                specified, the edges are added to the MedRecord without a group.
 
         Returns:
             List[EdgeIndex]: A list of the edge indices added.
         """
-        return self._medrecord.add_edges_dataframes(
+        edge_indices = self._medrecord.add_edges_dataframes(
             edges if isinstance(edges, list) else [edges]
         )
+        if group is not None:
+            if not self.contains_group(group):
+                self.add_group(group)
+            self.add_edge_to_group(group, edge_indices)
+
+        return edge_indices
 
     def add_group(
         self,

--- a/medmodels/medrecord/tests/test_builder.py
+++ b/medmodels/medrecord/tests/test_builder.py
@@ -62,3 +62,8 @@ class TestMedRecordBuilder(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             medrecord.add_node("node", {"attribute": "1"})
+
+
+if __name__ == "__main__":
+    run_test = unittest.TestLoader().loadTestsFromTestCase(TestMedRecordBuilder)
+    unittest.TextTestRunner(verbosity=2).run(run_test)

--- a/medmodels/medrecord/tests/test_medrecord.py
+++ b/medmodels/medrecord/tests/test_medrecord.py
@@ -475,6 +475,14 @@ class TestMedRecord(unittest.TestCase):
         medrecord.add_node("0", {})
 
         self.assertEqual(1, medrecord.node_count())
+        self.assertEqual(0, len(medrecord.groups))
+
+        medrecord = MedRecord()
+
+        medrecord.add_node("0", {}, "0")
+
+        self.assertIn("0", medrecord.nodes_in_group("0"))
+        self.assertEqual(1, len(medrecord.groups))
 
     def test_invalid_add_node(self):
         medrecord = create_medrecord()
@@ -530,6 +538,25 @@ class TestMedRecord(unittest.TestCase):
 
         self.assertEqual(4, medrecord.node_count())
 
+        # Adding tuple to a group
+        medrecord = MedRecord()
+
+        medrecord.add_nodes(create_nodes(), "0")
+
+        self.assertIn("0", medrecord.nodes_in_group("0"))
+        self.assertIn("1", medrecord.nodes_in_group("0"))
+        self.assertIn("2", medrecord.nodes_in_group("0"))
+        self.assertIn("3", medrecord.nodes_in_group("0"))
+        self.assertIn("0", medrecord.groups)
+
+        # Adding group without nodes
+        medrecord = MedRecord()
+
+        medrecord.add_nodes([], "0")
+
+        self.assertEqual(0, medrecord.node_count())
+        self.assertIn("0", medrecord.groups)
+
         # Adding pandas dataframe
         medrecord = MedRecord()
 
@@ -538,6 +565,14 @@ class TestMedRecord(unittest.TestCase):
         medrecord.add_nodes((create_pandas_nodes_dataframe(), "index"))
 
         self.assertEqual(2, medrecord.node_count())
+
+        # Adding pandas dataframe to a group
+        medrecord = MedRecord()
+
+        medrecord.add_nodes((create_pandas_nodes_dataframe(), "index"), "0")
+
+        self.assertIn("0", medrecord.nodes_in_group("0"))
+        self.assertIn("1", medrecord.nodes_in_group("0"))
 
         # Adding polars dataframe
         medrecord = MedRecord()
@@ -549,6 +584,14 @@ class TestMedRecord(unittest.TestCase):
         medrecord.add_nodes((nodes, "index"))
 
         self.assertEqual(2, medrecord.node_count())
+
+        # Adding polars dataframe to a group
+        medrecord = MedRecord()
+
+        medrecord.add_nodes((nodes, "index"), "0")
+
+        self.assertIn("0", medrecord.nodes_in_group("0"))
+        self.assertIn("1", medrecord.nodes_in_group("0"))
 
         # Adding multiple pandas dataframes
         medrecord = MedRecord()
@@ -563,6 +606,39 @@ class TestMedRecord(unittest.TestCase):
         )
 
         self.assertEqual(4, medrecord.node_count())
+
+        # Adding multiple pandas dataframes to a group
+        medrecord = MedRecord()
+
+        medrecord.add_nodes(
+            [
+                (create_pandas_nodes_dataframe(), "index"),
+                (create_second_pandas_nodes_dataframe(), "index"),
+            ],
+            group="0",
+        )
+
+        self.assertIn("0", medrecord.nodes_in_group("0"))
+        self.assertIn("1", medrecord.nodes_in_group("0"))
+        self.assertIn("2", medrecord.nodes_in_group("0"))
+        self.assertIn("3", medrecord.nodes_in_group("0"))
+
+        # Checking if nodes can be added to a group that already exists
+        medrecord = MedRecord()
+
+        medrecord.add_nodes((create_pandas_nodes_dataframe(), "index"), group="0")
+
+        self.assertIn("0", medrecord.nodes_in_group("0"))
+        self.assertIn("1", medrecord.nodes_in_group("0"))
+        self.assertNotIn("2", medrecord.nodes_in_group("0"))
+        self.assertNotIn("3", medrecord.nodes_in_group("0"))
+
+        medrecord.add_nodes(
+            (create_second_pandas_nodes_dataframe(), "index"), group="0"
+        )
+
+        self.assertIn("2", medrecord.nodes_in_group("0"))
+        self.assertIn("3", medrecord.nodes_in_group("0"))
 
         # Adding multiple polars dataframes
         medrecord = MedRecord()
@@ -580,6 +656,22 @@ class TestMedRecord(unittest.TestCase):
 
         self.assertEqual(4, medrecord.node_count())
 
+        # Adding multiple polars dataframes to a group
+        medrecord = MedRecord()
+
+        medrecord.add_nodes(
+            [
+                (nodes, "index"),
+                (second_nodes, "index"),
+            ],
+            group="0",
+        )
+
+        self.assertIn("0", medrecord.nodes_in_group("0"))
+        self.assertIn("1", medrecord.nodes_in_group("0"))
+        self.assertIn("2", medrecord.nodes_in_group("0"))
+        self.assertIn("3", medrecord.nodes_in_group("0"))
+
     def test_invalid_add_nodes(self):
         medrecord = create_medrecord()
 
@@ -593,7 +685,7 @@ class TestMedRecord(unittest.TestCase):
 
         self.assertEqual(0, medrecord.node_count())
 
-        medrecord.add_nodes(nodes)
+        medrecord.add_nodes_pandas(nodes)
 
         self.assertEqual(2, medrecord.node_count())
 
@@ -603,9 +695,33 @@ class TestMedRecord(unittest.TestCase):
 
         self.assertEqual(0, medrecord.node_count())
 
-        medrecord.add_nodes([nodes, second_nodes])
+        medrecord.add_nodes_pandas([nodes, second_nodes])
 
         self.assertEqual(4, medrecord.node_count())
+
+        # Trying with the group argument
+        medrecord = MedRecord()
+
+        medrecord.add_nodes_pandas(nodes, group="0")
+
+        self.assertIn("0", medrecord.nodes_in_group("0"))
+        self.assertIn("1", medrecord.nodes_in_group("0"))
+
+        medrecord = MedRecord()
+
+        medrecord.add_nodes_pandas([], group="0")
+
+        self.assertEqual(0, medrecord.node_count())
+        self.assertIn("0", medrecord.groups)
+
+        medrecord = MedRecord()
+
+        medrecord.add_nodes_pandas([nodes, second_nodes], group="0")
+
+        self.assertIn("0", medrecord.nodes_in_group("0"))
+        self.assertIn("1", medrecord.nodes_in_group("0"))
+        self.assertIn("2", medrecord.nodes_in_group("0"))
+        self.assertIn("3", medrecord.nodes_in_group("0"))
 
     def test_add_nodes_polars(self):
         medrecord = MedRecord()
@@ -627,6 +743,32 @@ class TestMedRecord(unittest.TestCase):
         medrecord.add_nodes_polars([(nodes, "index"), (second_nodes, "index")])
 
         self.assertEqual(4, medrecord.node_count())
+
+        # Trying with the group argument
+        medrecord = MedRecord()
+
+        medrecord.add_nodes_polars((nodes, "index"), group="0")
+
+        self.assertIn("0", medrecord.nodes_in_group("0"))
+        self.assertIn("1", medrecord.nodes_in_group("0"))
+
+        medrecord = MedRecord()
+
+        medrecord.add_nodes_polars([], group="0")
+
+        self.assertEqual(0, medrecord.node_count())
+        self.assertIn("0", medrecord.groups)
+
+        medrecord = MedRecord()
+
+        medrecord.add_nodes_polars(
+            [(nodes, "index"), (second_nodes, "index")], group="0"
+        )
+
+        self.assertIn("0", medrecord.nodes_in_group("0"))
+        self.assertIn("1", medrecord.nodes_in_group("0"))
+        self.assertIn("2", medrecord.nodes_in_group("0"))
+        self.assertIn("3", medrecord.nodes_in_group("0"))
 
     def test_invalid_add_nodes_polars(self):
         medrecord = MedRecord()
@@ -650,6 +792,11 @@ class TestMedRecord(unittest.TestCase):
         medrecord.add_edge("0", "3", {})
 
         self.assertEqual(5, medrecord.edge_count())
+
+        medrecord.add_edge("3", "0", {}, group="0")
+
+        self.assertEqual(6, medrecord.edge_count())
+        self.assertIn(5, medrecord.edges_in_group("0"))
 
     def test_invalid_add_edge(self):
         medrecord = MedRecord()
@@ -710,6 +857,19 @@ class TestMedRecord(unittest.TestCase):
 
         self.assertEqual(4, medrecord.edge_count())
 
+        # Adding tuple to a group
+
+        medrecord = MedRecord()
+
+        medrecord.add_nodes(nodes)
+
+        medrecord.add_edges(create_edges(), "0")
+
+        self.assertIn(0, medrecord.edges_in_group("0"))
+        self.assertIn(1, medrecord.edges_in_group("0"))
+        self.assertIn(2, medrecord.edges_in_group("0"))
+        self.assertIn(3, medrecord.edges_in_group("0"))
+
         # Adding pandas dataframe
         medrecord = MedRecord()
 
@@ -720,6 +880,16 @@ class TestMedRecord(unittest.TestCase):
         medrecord.add_edges((create_pandas_edges_dataframe(), "source", "target"))
 
         self.assertEqual(2, medrecord.edge_count())
+
+        # Adding pandas dataframe to a group
+        medrecord = MedRecord()
+
+        medrecord.add_nodes(nodes)
+
+        medrecord.add_edges((create_pandas_edges_dataframe(), "source", "target"), "0")
+
+        self.assertIn(0, medrecord.edges_in_group("0"))
+        self.assertIn(1, medrecord.edges_in_group("0"))
 
         # Adding polars dataframe
         medrecord = MedRecord()
@@ -733,6 +903,16 @@ class TestMedRecord(unittest.TestCase):
         medrecord.add_edges((edges, "source", "target"))
 
         self.assertEqual(2, medrecord.edge_count())
+
+        # Adding polars dataframe to a group
+        medrecord = MedRecord()
+
+        medrecord.add_nodes(nodes)
+
+        medrecord.add_edges((edges, "source", "target"), "0")
+
+        self.assertIn(0, medrecord.edges_in_group("0"))
+        self.assertIn(1, medrecord.edges_in_group("0"))
 
         # Adding multiple pandas dataframe
         medrecord = MedRecord()
@@ -750,7 +930,25 @@ class TestMedRecord(unittest.TestCase):
 
         self.assertEqual(4, medrecord.edge_count())
 
-        # Adding multiple polats dataframe
+        # Adding multiple pandas dataframe to a group
+        medrecord = MedRecord()
+
+        medrecord.add_nodes(nodes)
+
+        medrecord.add_edges(
+            [
+                (create_pandas_edges_dataframe(), "source", "target"),
+                (create_second_pandas_edges_dataframe(), "source", "target"),
+            ],
+            "0",
+        )
+
+        self.assertIn(0, medrecord.edges_in_group("0"))
+        self.assertIn(1, medrecord.edges_in_group("0"))
+        self.assertIn(2, medrecord.edges_in_group("0"))
+        self.assertIn(3, medrecord.edges_in_group("0"))
+
+        # Adding multiple polars dataframe
         medrecord = MedRecord()
 
         medrecord.add_nodes(nodes)
@@ -768,6 +966,24 @@ class TestMedRecord(unittest.TestCase):
 
         self.assertEqual(4, medrecord.edge_count())
 
+        # Adding multiple polars dataframe to a group
+        medrecord = MedRecord()
+
+        medrecord.add_nodes(nodes)
+
+        medrecord.add_edges(
+            [
+                (edges, "source", "target"),
+                (second_edges, "source", "target"),
+            ],
+            "0",
+        )
+
+        self.assertIn(0, medrecord.edges_in_group("0"))
+        self.assertIn(1, medrecord.edges_in_group("0"))
+        self.assertIn(2, medrecord.edges_in_group("0"))
+        self.assertIn(3, medrecord.edges_in_group("0"))
+
     def test_add_edges_pandas(self):
         medrecord = MedRecord()
 
@@ -783,6 +999,29 @@ class TestMedRecord(unittest.TestCase):
 
         self.assertEqual(2, medrecord.edge_count())
 
+        # Adding to a group
+        medrecord = MedRecord()
+
+        medrecord.add_nodes(nodes)
+
+        medrecord.add_edges(edges, "0")
+
+        self.assertIn(0, medrecord.edges_in_group("0"))
+        self.assertIn(1, medrecord.edges_in_group("0"))
+
+        medrecord = MedRecord()
+
+        medrecord.add_nodes(nodes)
+
+        second_edges = (create_second_pandas_edges_dataframe(), "source", "target")
+
+        medrecord.add_edges([edges, second_edges], "0")
+
+        self.assertIn(0, medrecord.edges_in_group("0"))
+        self.assertIn(1, medrecord.edges_in_group("0"))
+        self.assertIn(2, medrecord.edges_in_group("0"))
+        self.assertIn(3, medrecord.edges_in_group("0"))
+
     def test_add_edges_polars(self):
         medrecord = MedRecord()
 
@@ -797,6 +1036,31 @@ class TestMedRecord(unittest.TestCase):
         medrecord.add_edges_polars((edges, "source", "target"))
 
         self.assertEqual(2, medrecord.edge_count())
+
+        # Adding to a group
+        medrecord = MedRecord()
+
+        medrecord.add_nodes(nodes)
+
+        medrecord.add_edges_polars((edges, "source", "target"), "0")
+
+        self.assertIn(0, medrecord.edges_in_group("0"))
+        self.assertIn(1, medrecord.edges_in_group("0"))
+
+        medrecord = MedRecord()
+
+        medrecord.add_nodes(nodes)
+
+        second_edges = pl.from_pandas(create_second_pandas_edges_dataframe())
+
+        medrecord.add_edges_polars(
+            [(edges, "source", "target"), (second_edges, "source", "target")], "0"
+        )
+
+        self.assertIn(0, medrecord.edges_in_group("0"))
+        self.assertIn(1, medrecord.edges_in_group("0"))
+        self.assertIn(2, medrecord.edges_in_group("0"))
+        self.assertIn(3, medrecord.edges_in_group("0"))
 
     def test_invalid_add_edges_polars(self):
         medrecord = MedRecord()


### PR DESCRIPTION
The add_nodes function now allows for adding nodes directly to a group with the function.

```python

medrecord = MedRecord()
medrecord.add_nodes(nodes, group)
```