### PR TITLE
fix: Renaming absolute risk function for correct one (absolute risk reduction)

### DIFF
--- a/medmodels/treatment_effect/estimate.py
+++ b/medmodels/treatment_effect/estimate.py
@@ -318,19 +318,19 @@ class Estimate:
 
         return numerator / denominator
 
-    def risk_difference(self, medrecord: MedRecord) -> float:
-        """Calculates the risk difference (RD) - also called absolute risk reduction (ARR) - of an event occurring in the treatment group compared to the control group.
+    def absolute_risk_reduction(self, medrecord: MedRecord) -> float:
+        """Calculates the absolute risk reduction (ARR) of an event occurring in the treatment group compared to the control group.
 
-        AR is a measure of the incidence of an event in each group. RD quantifies in
-        turn the difference in risk between the treatment and control groups and is
-        positive if the treatment reduces the risk and negative if it increases the
+        AR is a measure of the incidence of an event in each group. ARR quantifies in
+        turn the difference in risk between the treatment and control groups. It is
+        positive if the treatment reduces the risk, and negative if it increases the
         risk.
 
         Args:
             medrecord (MedRecord): The MedRecord object containing the data.
 
         Returns:
-            float: The calculated risk difference between the treatment and
+            float: The calculated absolute risk reduction between the treatment and
                 control groups.
 
         Raises:
@@ -347,16 +347,16 @@ class Estimate:
             num_control_false,
         ) = self._compute_subject_counts(medrecord)
 
-        risk_treat = num_treat_true / (num_treat_true + num_treat_false)
-        risk_control = num_control_true / (num_control_true + num_control_false)
+        risk_treat_group = num_treat_true / (num_treat_true + num_treat_false)
+        risk_control_group = num_control_true / (num_control_true + num_control_false)
 
-        return risk_treat - risk_control
+        return risk_control_group - risk_treat_group
 
     def number_needed_to_treat(self, medrecord: MedRecord) -> float:
         """Calculates the number needed to treat (NNT) to prevent one additional bad outcome.
 
-        NNT is derived from the risk difference (RD) and provides an estimate of the
-        number of patients that need to be treated to prevent one additional bad
+        NNT is derived from the absolute risk reduction (ARR) and provides an estimate
+        of the number of patients that need to be treated to prevent one additional bad
         outcome.
 
         Args:
@@ -372,12 +372,12 @@ class Estimate:
             ValueError: If there are no subjects in the treatment false, control true
                 or control false groups in the contingency table. This would result in
                 division by zero errors.
-            ValueError: If the risk difference is zero, cannot calculate NNT.
+            ValueError: If the ARR is zero, cannot calculate NNT.
         """
-        risk_difference = self.risk_difference(medrecord)
-        if risk_difference == 0:
-            raise ValueError("Risk difference is zero, cannot calculate NNT.")
-        return 1 / risk_difference
+        absolute_risk_reduction = self.absolute_risk_reduction(medrecord)
+        if absolute_risk_reduction == 0:
+            raise ValueError("Absolute Risk Reduction is zero, cannot calculate NNT.")
+        return 1 / absolute_risk_reduction
 
     def hazard_ratio(self, medrecord: MedRecord) -> float:
         """Calculates the hazard ratio (HR) for the treatment group compared to the control group.

--- a/medmodels/treatment_effect/estimate.py
+++ b/medmodels/treatment_effect/estimate.py
@@ -318,16 +318,19 @@ class Estimate:
 
         return numerator / denominator
 
-    def absolute_risk(self, medrecord: MedRecord) -> float:
-        """Calculates the absolute risk (AR) of an event occurring in the treatment group compared to the control group.
+    def risk_difference(self, medrecord: MedRecord) -> float:
+        """Calculates the risk difference (RD) - also called absolute risk reduction (ARR) - of an event occurring in the treatment group compared to the control group.
 
-        AR is a measure of the incidence of an event in each group.
+        AR is a measure of the incidence of an event in each group. RD quantifies in
+        turn the difference in risk between the treatment and control groups and is
+        positive if the treatment reduces the risk and negative if it increases the
+        risk.
 
         Args:
             medrecord (MedRecord): The MedRecord object containing the data.
 
         Returns:
-            float: The calculated absolute risk difference between the treatment and
+            float: The calculated risk difference between the treatment and
                 control groups.
 
         Raises:
@@ -352,7 +355,9 @@ class Estimate:
     def number_needed_to_treat(self, medrecord: MedRecord) -> float:
         """Calculates the number needed to treat (NNT) to prevent one additional bad outcome.
 
-        NNT is derived from the absolute risk reduction.
+        NNT is derived from the risk difference (RD) and provides an estimate of the
+        number of patients that need to be treated to prevent one additional bad
+        outcome.
 
         Args:
             medrecord (MedRecord): The MedRecord object containing the data.
@@ -367,12 +372,12 @@ class Estimate:
             ValueError: If there are no subjects in the treatment false, control true
                 or control false groups in the contingency table. This would result in
                 division by zero errors.
-            ValueError: If the absolute risk is zero, cannot calculate NNT.
+            ValueError: If the risk difference is zero, cannot calculate NNT.
         """
-        ar = self.absolute_risk(medrecord)
-        if ar == 0:
-            raise ValueError("Absolute risk is zero, cannot calculate NNT.")
-        return 1 / ar
+        risk_difference = self.risk_difference(medrecord)
+        if risk_difference == 0:
+            raise ValueError("Risk difference is zero, cannot calculate NNT.")
+        return 1 / risk_difference
 
     def hazard_ratio(self, medrecord: MedRecord) -> float:
         """Calculates the hazard ratio (HR) for the treatment group compared to the control group.

--- a/medmodels/treatment_effect/report.py
+++ b/medmodels/treatment_effect/report.py
@@ -13,7 +13,7 @@ class FullReport(TypedDict):
     relative_risk: float
     odds_ratio: float
     confounding_bias: float
-    risk_difference: float
+    absolute_risk_reduction: float
     number_needed_to_treat: float
     hazard_ratio: float
 
@@ -38,8 +38,8 @@ class Report:
 
         Returns:
             FullReport: A dictionary containing the results of all estimation
-                methods: relative risk, odds ratio, confounding bias, risk_difference,
-                number needed to treat, and hazard ratio.
+                methods: relative risk, odds ratio, confounding bias, absolute risk
+                reduction, number needed to treat, and hazard ratio.
         """
         return {
             "relative_risk": self._treatment_effect.estimate.relative_risk(medrecord),
@@ -47,7 +47,7 @@ class Report:
             "confounding_bias": self._treatment_effect.estimate.confounding_bias(
                 medrecord
             ),
-            "risk_difference": self._treatment_effect.estimate.risk_difference(
+            "absolute_risk_reduction": self._treatment_effect.estimate.absolute_risk_reduction(
                 medrecord
             ),
             "number_needed_to_treat": self._treatment_effect.estimate.number_needed_to_treat(

--- a/medmodels/treatment_effect/report.py
+++ b/medmodels/treatment_effect/report.py
@@ -13,7 +13,7 @@ class FullReport(TypedDict):
     relative_risk: float
     odds_ratio: float
     confounding_bias: float
-    absolute_risk: float
+    risk_difference: float
     number_needed_to_treat: float
     hazard_ratio: float
 
@@ -38,7 +38,7 @@ class Report:
 
         Returns:
             FullReport: A dictionary containing the results of all estimation
-                methods: relative risk, odds ratio, confounding bias, absolute risk,
+                methods: relative risk, odds ratio, confounding bias, risk_difference,
                 number needed to treat, and hazard ratio.
         """
         return {
@@ -47,7 +47,9 @@ class Report:
             "confounding_bias": self._treatment_effect.estimate.confounding_bias(
                 medrecord
             ),
-            "absolute_risk": self._treatment_effect.estimate.absolute_risk(medrecord),
+            "risk_difference": self._treatment_effect.estimate.risk_difference(
+                medrecord
+            ),
             "number_needed_to_treat": self._treatment_effect.estimate.number_needed_to_treat(
                 medrecord
             ),

--- a/medmodels/treatment_effect/tests/test_treatment_effect.py
+++ b/medmodels/treatment_effect/tests/test_treatment_effect.py
@@ -724,7 +724,7 @@ class TestTreatmentEffect(unittest.TestCase):
         )
 
         # Calculate metrics
-        self.assertAlmostEqual(tee.estimate.absolute_risk(self.medrecord), 1 / 6)
+        self.assertAlmostEqual(tee.estimate.risk_difference(self.medrecord), 1 / 6)
         self.assertAlmostEqual(tee.estimate.relative_risk(self.medrecord), 4 / 3)
         self.assertAlmostEqual(tee.estimate.odds_ratio(self.medrecord), 2)
         self.assertAlmostEqual(tee.estimate.confounding_bias(self.medrecord), 22 / 21)
@@ -744,7 +744,7 @@ class TestTreatmentEffect(unittest.TestCase):
         full_report = tee.report.full_report(self.medrecord)
 
         report_test = {
-            "absolute_risk": tee.estimate.absolute_risk(self.medrecord),
+            "risk_difference": tee.estimate.risk_difference(self.medrecord),
             "relative_risk": tee.estimate.relative_risk(self.medrecord),
             "odds_ratio": tee.estimate.odds_ratio(self.medrecord),
             "confounding_bias": tee.estimate.confounding_bias(self.medrecord),

--- a/medmodels/treatment_effect/tests/test_treatment_effect.py
+++ b/medmodels/treatment_effect/tests/test_treatment_effect.py
@@ -724,12 +724,14 @@ class TestTreatmentEffect(unittest.TestCase):
         )
 
         # Calculate metrics
-        self.assertAlmostEqual(tee.estimate.risk_difference(self.medrecord), 1 / 6)
+        self.assertAlmostEqual(
+            tee.estimate.absolute_risk_reduction(self.medrecord), -1 / 6
+        )
         self.assertAlmostEqual(tee.estimate.relative_risk(self.medrecord), 4 / 3)
         self.assertAlmostEqual(tee.estimate.odds_ratio(self.medrecord), 2)
         self.assertAlmostEqual(tee.estimate.confounding_bias(self.medrecord), 22 / 21)
         self.assertAlmostEqual(tee.estimate.hazard_ratio(self.medrecord), 4 / 3)
-        self.assertAlmostEqual(tee.estimate.number_needed_to_treat(self.medrecord), 6)
+        self.assertAlmostEqual(tee.estimate.number_needed_to_treat(self.medrecord), -6)
 
     def test_full_report(self):
         """Test the full reporting of the TreatmentEffect class."""
@@ -744,7 +746,9 @@ class TestTreatmentEffect(unittest.TestCase):
         full_report = tee.report.full_report(self.medrecord)
 
         report_test = {
-            "risk_difference": tee.estimate.risk_difference(self.medrecord),
+            "absolute_risk_reduction": tee.estimate.absolute_risk_reduction(
+                self.medrecord
+            ),
             "relative_risk": tee.estimate.relative_risk(self.medrecord),
             "odds_ratio": tee.estimate.odds_ratio(self.medrecord),
             "confounding_bias": tee.estimate.confounding_bias(self.medrecord),


### PR DESCRIPTION
The previously named "absolute risk" function in the TreatmentEffect Estimate module was wrongly named like that. The implementation corresponded actually to "absolute risk reduction".