### PR TITLE
feat: removing singular name functions and changing them to plural naming

### DIFF
--- a/docs/user_guide/getstarted.md
+++ b/docs/user_guide/getstarted.md
@@ -301,25 +301,13 @@ patient_drug_edges = medrecord.add_edges_polars(
 )
 ```
 
-### Adding single entries
-
-Single nodes can be added or removed to an existing MedRecord by their unique identifier. Attributes can also be added during that process.
-
-Single edges between a source node and target node can be added to the MedRecord instance by specifiying the source and the target node identifier. Attributes for the connection can also be included.
-
-```python
-medrecord.add_node(node="pat_6", attributes={"age": 67, "gender": "F"})
-# add connection between nodes, will return the edge identifier
-edge_pat6_pat2_id = medrecord.add_edge(
-    source_node="pat_6", target_node="pat_2", attributes={"relationship": "Mother"}
-)
-```
+### Removing entries
 
 Nodes and edges can be easily removed by their identifier. To check if a node or edge exists, the `contain_node()` or `contain_edge()` functions can be used. If a node is deleted from the MedRecord, its corresponding edges will also be removed.
 
 ```python
 # returns attributes for the node that will be removed
-medrecord.remove_node("pat_6")
+medrecord.remove_nodes("pat_6")
 medrecord.contains_node("pat_6") or medrecord.contains_edge(edge_pat6_pat2_id)
 ```
 
@@ -434,7 +422,7 @@ additional_young_id = medrecord.select_nodes(
     node().attribute("age").greater_or_equal(young_age)
     & node().attribute("age").less(higher_age)
 )
-medrecord.add_node_to_group(group="Young", node=additional_young_id)
+medrecord.add_nodes_to_group(group="Young", node=additional_young_id)
 
 print(
     f"Patients in Group 'Young' if threshold age is {higher_age}: {medrecord.group('Young')}"
@@ -446,12 +434,12 @@ print(
 It is possible to remove nodes from groups and to remove groups entirely from the MedRecord.
 
 ```python
-medrecord.remove_node_from_group(group="Young", node=additional_young_id)
+medrecord.remove_nodes_from_group(group="Young", node=additional_young_id)
 print(f"Patients in group 'Young': {medrecord.select_nodes(node().in_group('Young'))}")
 
 
 print(f"The MedRecord contains {medrecord.group_count()} groups.")
-medrecord.remove_group("Woman")
+medrecord.remove_groups("Woman")
 print(
     f"After the removal operation, the MedRecord contains {medrecord.group_count()} groups."
 )

--- a/docs/user_guide/getstarted.md
+++ b/docs/user_guide/getstarted.md
@@ -303,7 +303,7 @@ patient_drug_edges = medrecord.add_edges_polars(
 
 ### Removing entries
 
-Nodes and edges can be easily removed by their identifier. To check if a node or edge exists, the `contain_node()` or `contain_edge()` functions can be used. If a node is deleted from the MedRecord, its corresponding edges will also be removed.
+Nodes and edges can be easily removed by their identifier. To check if a node or edge exists, the `contains_node()` or `contains_edge()` functions can be used. If a node is deleted from the MedRecord, its corresponding edges will also be removed.
 
 ```python
 # returns attributes for the node that will be removed
@@ -422,7 +422,7 @@ additional_young_id = medrecord.select_nodes(
     node().attribute("age").greater_or_equal(young_age)
     & node().attribute("age").less(higher_age)
 )
-medrecord.add_nodes_to_group(group="Young", node=additional_young_id)
+medrecord.add_nodes_to_group(group="Young", nodes=additional_young_id)
 
 print(
     f"Patients in Group 'Young' if threshold age is {higher_age}: {medrecord.group('Young')}"
@@ -434,7 +434,7 @@ print(
 It is possible to remove nodes from groups and to remove groups entirely from the MedRecord.
 
 ```python
-medrecord.remove_nodes_from_group(group="Young", node=additional_young_id)
+medrecord.remove_nodes_from_group(group="Young", nodes=additional_young_id)
 print(f"Patients in group 'Young': {medrecord.select_nodes(node().in_group('Young'))}")
 
 

--- a/medmodels/_medmodels.pyi
+++ b/medmodels/_medmodels.pyi
@@ -156,8 +156,7 @@ class PyMedRecord:
         source_node_indices: NodeIndexInputList,
         target_node_indices: NodeIndexInputList,
     ) -> List[EdgeIndex]: ...
-    def add_node(self, node_index: NodeIndex, attributes: AttributesInput) -> None: ...
-    def remove_node(
+    def remove_nodes(
         self, node_index: NodeIndexInputList
     ) -> Dict[NodeIndex, Attributes]: ...
     def replace_node_attributes(
@@ -176,13 +175,7 @@ class PyMedRecord:
     def add_nodes_dataframes(
         self, nodes_dataframe: List[PolarsNodeDataFrameInput]
     ) -> None: ...
-    def add_edge(
-        self,
-        source_node_index: NodeIndex,
-        target_node_index: NodeIndex,
-        attributes: AttributesInput,
-    ) -> EdgeIndex: ...
-    def remove_edge(
+    def remove_edges(
         self, edge_index: EdgeIndexInputList
     ) -> Dict[EdgeIndex, Attributes]: ...
     def replace_edge_attributes(
@@ -207,17 +200,17 @@ class PyMedRecord:
         node_indices_to_add: Optional[NodeIndexInputList],
         edge_indices_to_add: Optional[EdgeIndexInputList],
     ) -> None: ...
-    def remove_group(self, group: GroupInputList) -> None: ...
-    def add_node_to_group(
+    def remove_groups(self, group: GroupInputList) -> None: ...
+    def add_nodes_to_group(
         self, group: Group, node_index: NodeIndexInputList
     ) -> None: ...
-    def add_edge_to_group(
+    def add_edges_to_group(
         self, group: Group, edge_index: EdgeIndexInputList
     ) -> None: ...
-    def remove_node_from_group(
+    def remove_nodes_from_group(
         self, group: Group, node_index: NodeIndexInputList
     ) -> None: ...
-    def remove_edge_from_group(
+    def remove_edges_from_group(
         self, group: Group, edge_index: EdgeIndexInputList
     ) -> None: ...
     def nodes_in_group(self, group: GroupInputList) -> Dict[Group, List[NodeIndex]]: ...

--- a/medmodels/medrecord/medrecord.py
+++ b/medmodels/medrecord/medrecord.py
@@ -570,15 +570,15 @@ class MedRecord:
             )
 
     @overload
-    def remove_nodes(self, node: NodeIndex) -> Attributes: ...
+    def remove_nodes(self, nodes: NodeIndex) -> Attributes: ...
 
     @overload
     def remove_nodes(
-        self, node: Union[NodeIndexInputList, NodeOperation]
+        self, nodes: Union[NodeIndexInputList, NodeOperation]
     ) -> Dict[NodeIndex, Attributes]: ...
 
     def remove_nodes(
-        self, node: Union[NodeIndex, NodeIndexInputList, NodeOperation]
+        self, nodes: Union[NodeIndex, NodeIndexInputList, NodeOperation]
     ) -> Union[Attributes, Dict[NodeIndex, Attributes]]:
         """Removes a node or multiple nodes from the MedRecord and returns their attributes.
 
@@ -587,24 +587,24 @@ class MedRecord:
         index to its attributes.
 
         Args:
-            node (Union[NodeIndex, NodeIndexInputList, NodeOperation]): One or more
+            nodes (Union[NodeIndex, NodeIndexInputList, NodeOperation]): One or more
                 node indices or a node operation.
 
         Returns:
             Union[Attributes, Dict[NodeIndex, Attributes]]: Attributes of the
                 removed node(s).
         """
-        if isinstance(node, NodeOperation):
-            return self._medrecord.remove_nodes(self.select_nodes(node))
+        if isinstance(nodes, NodeOperation):
+            return self._medrecord.remove_nodes(self.select_nodes(nodes))
 
         attributes = self._medrecord.remove_nodes(
-            node if isinstance(node, list) else [node]
+            nodes if isinstance(nodes, list) else [nodes]
         )
 
-        if isinstance(node, list):
+        if isinstance(nodes, list):
             return attributes
 
-        return attributes[node]
+        return attributes[nodes]
 
     def add_nodes(
         self,
@@ -785,6 +785,7 @@ class MedRecord:
         else:
             if is_edge_tuple(edges):
                 edges = [edges]
+
             edge_indices = self._medrecord.add_edges(edges)
 
             if group is None:
@@ -906,101 +907,101 @@ class MedRecord:
         else:
             return self._medrecord.add_group(group, None, None)
 
-    def remove_groups(self, group: Union[Group, GroupInputList]) -> None:
+    def remove_groups(self, groups: Union[Group, GroupInputList]) -> None:
         """Removes one or more groups from the MedRecord instance.
 
         Args:
-            group (Union[Group, GroupInputList]): One or more group names to remove.
+            groups (Union[Group, GroupInputList]): One or more group names to remove.
 
         Returns:
             None
         """
         return self._medrecord.remove_groups(
-            group if isinstance(group, list) else [group]
+            groups if isinstance(groups, list) else [groups]
         )
 
     def add_nodes_to_group(
-        self, group: Group, node: Union[NodeIndex, NodeIndexInputList, NodeOperation]
+        self, group: Group, nodes: Union[NodeIndex, NodeIndexInputList, NodeOperation]
     ) -> None:
         """Adds one or more nodes to a specified group in the MedRecord.
 
         Args:
             group (Group): The name of the group to add nodes to.
-            node (Union[NodeIndex, NodeIndexInputList, NodeOperation]): One or more
+            nodes (Union[NodeIndex, NodeIndexInputList, NodeOperation]): One or more
                 node indices or a node operation to add to the group.
 
         Returns:
             None
         """
-        if isinstance(node, NodeOperation):
-            return self._medrecord.add_nodes_to_group(group, self.select_nodes(node))
+        if isinstance(nodes, NodeOperation):
+            return self._medrecord.add_nodes_to_group(group, self.select_nodes(nodes))
 
         return self._medrecord.add_nodes_to_group(
-            group, node if isinstance(node, list) else [node]
+            group, nodes if isinstance(nodes, list) else [nodes]
         )
 
     def add_edges_to_group(
-        self, group: Group, edge: Union[EdgeIndex, EdgeIndexInputList, EdgeOperation]
+        self, group: Group, edges: Union[EdgeIndex, EdgeIndexInputList, EdgeOperation]
     ) -> None:
         """Adds one or more edges to a specified group in the MedRecord.
 
         Args:
             group (Group): The name of the group to add edges to.
-            edge (Union[EdgeIndex, EdgeIndexInputList, EdgeOperation]): One or more
+            edges (Union[EdgeIndex, EdgeIndexInputList, EdgeOperation]): One or more
                 edge indices or an edge operation to add to the group.
 
         Returns:
             None
         """
-        if isinstance(edge, EdgeOperation):
-            return self._medrecord.add_edges_to_group(group, self.select_edges(edge))
+        if isinstance(edges, EdgeOperation):
+            return self._medrecord.add_edges_to_group(group, self.select_edges(edges))
 
         return self._medrecord.add_edges_to_group(
-            group, edge if isinstance(edge, list) else [edge]
+            group, edges if isinstance(edges, list) else [edges]
         )
 
     def remove_nodes_from_group(
-        self, group: Group, node: Union[NodeIndex, NodeIndexInputList, NodeOperation]
+        self, group: Group, nodes: Union[NodeIndex, NodeIndexInputList, NodeOperation]
     ) -> None:
         """Removes one or more nodes from a specified group in the MedRecord.
 
         Args:
             group (Group): The name of the group from which to remove nodes.
-            node (Union[NodeIndex, NodeIndexInputList, NodeOperation]): One or more
+            nodes (Union[NodeIndex, NodeIndexInputList, NodeOperation]): One or more
                 node indices or a node operation to remove from the group.
 
         Returns:
             None
         """
-        if isinstance(node, NodeOperation):
+        if isinstance(nodes, NodeOperation):
             return self._medrecord.remove_nodes_from_group(
-                group, self.select_nodes(node)
+                group, self.select_nodes(nodes)
             )
 
         return self._medrecord.remove_nodes_from_group(
-            group, node if isinstance(node, list) else [node]
+            group, nodes if isinstance(nodes, list) else [nodes]
         )
 
     def remove_edges_from_group(
-        self, group: Group, edge: Union[EdgeIndex, EdgeIndexInputList, EdgeOperation]
+        self, group: Group, edges: Union[EdgeIndex, EdgeIndexInputList, EdgeOperation]
     ) -> None:
         """Removes one or more edges from a specified group in the MedRecord.
 
         Args:
             group (Group): The name of the group from which to remove edges.
-            edge (Union[EdgeIndex, EdgeIndexInputList, EdgeOperation]): One or more
+            edges (Union[EdgeIndex, EdgeIndexInputList, EdgeOperation]): One or more
                 edge indices or an edge operation to remove from the group.
 
         Returns:
             None
         """
-        if isinstance(edge, EdgeOperation):
+        if isinstance(edges, EdgeOperation):
             return self._medrecord.remove_edges_from_group(
-                group, self.select_edges(edge)
+                group, self.select_edges(edges)
             )
 
         return self._medrecord.remove_edges_from_group(
-            group, edge if isinstance(edge, list) else [edge]
+            group, edges if isinstance(edges, list) else [edges]
         )
 
     @overload

--- a/medmodels/medrecord/medrecord.py
+++ b/medmodels/medrecord/medrecord.py
@@ -13,20 +13,23 @@ from medmodels.medrecord.schema import Schema
 from medmodels.medrecord.types import (
     AttributeInfo,
     Attributes,
-    AttributesInput,
     EdgeIndex,
     EdgeIndexInputList,
+    EdgeInput,
     EdgeTuple,
     Group,
     GroupInfo,
     GroupInputList,
     NodeIndex,
     NodeIndexInputList,
+    NodeInput,
     NodeTuple,
     PandasEdgeDataFrameInput,
     PandasNodeDataFrameInput,
     PolarsEdgeDataFrameInput,
     PolarsNodeDataFrameInput,
+    is_edge_tuple,
+    is_node_tuple,
     is_pandas_edge_dataframe_input,
     is_pandas_edge_dataframe_input_list,
     is_pandas_node_dataframe_input,
@@ -566,41 +569,15 @@ class MedRecord:
                 (target_node if isinstance(target_node, list) else [target_node]),
             )
 
-    def add_node(
-        self,
-        node: NodeIndex,
-        attributes: AttributesInput,
-        group: Optional[Group] = None,
-    ) -> None:
-        """Adds a node with specified attributes to the MedRecord instance. Optionally adds the node to a group.
-
-        Args:
-            node (NodeIndex): The index of the node to add.
-            attributes (Attributes): A dictionary of the node's attributes.
-            group (Optional[Group]): The name of the group to add the node to, optional.
-
-        Returns:
-            None
-        """
-        self._medrecord.add_node(node, attributes)
-
-        if group is None:
-            return
-
-        if not self.contains_group(group):
-            self.add_group(group)
-
-        self.add_node_to_group(group, node)
+    @overload
+    def remove_nodes(self, node: NodeIndex) -> Attributes: ...
 
     @overload
-    def remove_node(self, node: NodeIndex) -> Attributes: ...
-
-    @overload
-    def remove_node(
+    def remove_nodes(
         self, node: Union[NodeIndexInputList, NodeOperation]
     ) -> Dict[NodeIndex, Attributes]: ...
 
-    def remove_node(
+    def remove_nodes(
         self, node: Union[NodeIndex, NodeIndexInputList, NodeOperation]
     ) -> Union[Attributes, Dict[NodeIndex, Attributes]]:
         """Removes a node or multiple nodes from the MedRecord and returns their attributes.
@@ -618,9 +595,9 @@ class MedRecord:
                 removed node(s).
         """
         if isinstance(node, NodeOperation):
-            return self._medrecord.remove_node(self.select_nodes(node))
+            return self._medrecord.remove_nodes(self.select_nodes(node))
 
-        attributes = self._medrecord.remove_node(
+        attributes = self._medrecord.remove_nodes(
             node if isinstance(node, list) else [node]
         )
 
@@ -631,26 +608,19 @@ class MedRecord:
 
     def add_nodes(
         self,
-        nodes: Union[
-            Sequence[NodeTuple],
-            PandasNodeDataFrameInput,
-            List[PandasNodeDataFrameInput],
-            PolarsNodeDataFrameInput,
-            List[PolarsNodeDataFrameInput],
-        ],
+        nodes: NodeInput,
         group: Optional[Group] = None,
     ) -> None:
-        """Adds multiple nodes to the MedRecord from different data formats and optionally assigns them to a group.
+        """Adds nodes to the MedRecord from different data formats and optionally assigns them to a group.
 
-        Accepts a list of tuples, DataFrame(s), or PolarsNodeDataFrameInput(s) to add
-        nodes. If a DataFrame or list of DataFrames is used, the add_nodes_pandas method
-        is called. If PolarsNodeDataFrameInput(s) are provided, each tuple must include
-        a DataFrame and the index column. If a group is specified, the nodes are added
-        to the group.
+        Accepts a node tuple (single node added), a list of tuples, DataFrame(s), or
+        PolarsNodeDataFrameInput(s) to add nodes. If a DataFrame or list of DataFrames
+        is used, the add_nodes_pandas method is called. If PolarsNodeDataFrameInput(s)
+        are provided, each tuple must include a DataFrame and the index column. If a
+        group is specified, the nodes are added to the group.
 
         Args:
-            nodes (Union[Sequence[NodeTuple], PandasNodeDataFrameInput, List[PandasNodeDataFrameInput], PolarsNodeDataFrameInput, List[PolarsNodeDataFrameInput]]):
-                Data representing nodes in various formats.
+            nodes (NodeInput): Data representing nodes in various formats.
             group (Optional[Group]): The name of the group to add the nodes to. If not
                 specified, the nodes are added to the MedRecord without a group.
 
@@ -666,6 +636,9 @@ class MedRecord:
         ) or is_polars_node_dataframe_input_list(nodes):
             self.add_nodes_polars(nodes, group)
         else:
+            if is_node_tuple(nodes):
+                nodes = [nodes]
+
             self._medrecord.add_nodes(nodes)
 
             if group is None:
@@ -674,7 +647,7 @@ class MedRecord:
             if not self.contains_group(group):
                 self.add_group(group)
 
-            self.add_node_to_group(group, [node[0] for node in nodes])
+            self.add_nodes_to_group(group, [node[0] for node in nodes])
 
     def add_nodes_pandas(
         self,
@@ -740,49 +713,18 @@ class MedRecord:
         else:
             node_indices = nodes[0][nodes[1]].to_list()
 
-        self.add_node_to_group(group, node_indices)
-
-    def add_edge(
-        self,
-        source_node: NodeIndex,
-        target_node: NodeIndex,
-        attributes: AttributesInput,
-        group: Optional[Group] = None,
-    ) -> EdgeIndex:
-        """Adds an edge between two specified nodes with given attributes. Optionally assigns the edge to a group.
-
-        Args:
-            source_node (NodeIndex): Index of the source node.
-            target_node (NodeIndex): Index of the target node.
-            attributes (AttributesInput): Dictionary or mapping of edge attributes.
-            group (Optional[Group]): The name of the group to add the edge to. If not
-                specified, the edge is added to the MedRecord without a group.
-
-        Returns:
-            EdgeIndex: The index of the added edge.
-        """
-        edge_index = self._medrecord.add_edge(source_node, target_node, attributes)
-
-        if group is None:
-            return edge_index
-
-        if not self.contains_group(group):
-            self.add_group(group)
-
-        self.add_edge_to_group(group, edge_index)
-
-        return edge_index
+        self.add_nodes_to_group(group, node_indices)
 
     @overload
-    def remove_edge(self, edge: EdgeIndex) -> Attributes: ...
+    def remove_edges(self, edges: EdgeIndex) -> Attributes: ...
 
     @overload
-    def remove_edge(
-        self, edge: Union[EdgeIndexInputList, EdgeOperation]
+    def remove_edges(
+        self, edges: Union[EdgeIndexInputList, EdgeOperation]
     ) -> Dict[EdgeIndex, Attributes]: ...
 
-    def remove_edge(
-        self, edge: Union[EdgeIndex, EdgeIndexInputList, EdgeOperation]
+    def remove_edges(
+        self, edges: Union[EdgeIndex, EdgeIndexInputList, EdgeOperation]
     ) -> Union[Attributes, Dict[EdgeIndex, Attributes]]:
         """Removes an edge or multiple edges from the MedRecord and returns their attributes.
 
@@ -798,42 +740,34 @@ class MedRecord:
             Union[Attributes, Dict[EdgeIndex, Attributes]]: Attributes of the
                 removed edge(s).
         """
-        if isinstance(edge, EdgeOperation):
-            return self._medrecord.remove_edge(self.select_edges(edge))
+        if isinstance(edges, EdgeOperation):
+            return self._medrecord.remove_edges(self.select_edges(edges))
 
-        attributes = self._medrecord.remove_edge(
-            edge if isinstance(edge, list) else [edge]
+        attributes = self._medrecord.remove_edges(
+            edges if isinstance(edges, list) else [edges]
         )
 
-        if isinstance(edge, list):
+        if isinstance(edges, list):
             return attributes
 
-        return attributes[edge]
+        return attributes[edges]
 
     def add_edges(
         self,
-        edges: Union[
-            Sequence[EdgeTuple],
-            PandasEdgeDataFrameInput,
-            List[PandasEdgeDataFrameInput],
-            PolarsEdgeDataFrameInput,
-            List[PolarsEdgeDataFrameInput],
-        ],
+        edges: EdgeInput,
         group: Optional[Group] = None,
     ) -> List[EdgeIndex]:
         """Adds edges to the MedRecord instance from various data formats. Optionally assigns them to a group.
 
-        Accepts lists of tuples, DataFrame(s), or EdgeDataFrameInput(s) to add edges.
-        Each tuple must have indices for source and target nodes and a dictionary of
-        attributes. If a DataFrame or list of DataFrames is used,
-        the add_edges_dataframe method is invoked. If PolarsEdgeDataFrameInput(s) are
+        Accepts edge tuple, lists of tuples, DataFrame(s), or EdgeDataFrameInput(s) to
+        add edges. Each tuple must have indices for source and target nodes and a
+        dictionary of attributes. If a DataFrame or list of DataFrames is used, the
+        add_edges_dataframe method is invoked. If PolarsEdgeDataFrameInput(s) are
         provided, each tuple must include a DataFrame and index columns for source and
         target nodes. If a group is specified, the edges are added to the group.
 
         Args:
-            edges (Union[Sequence[EdgeTuple], PandasEdgeDataFrameInput, List[PolarsEdgeDataFrameInput]]):
-                List[PandasEdgeDataFrameInput], PolarsEdgeDataFrameInput,
-                Data representing edges in several formats.
+            edges (EdgeInput): Data representing edges in several formats.
             group (Optional[Group]): The name of the group to add the edges to. If not
                 specified, the edges are added to the MedRecord without a group.
 
@@ -849,6 +783,8 @@ class MedRecord:
         ) or is_polars_edge_dataframe_input_list(edges):
             return self.add_edges_polars(edges, group)
         else:
+            if is_edge_tuple(edges):
+                edges = [edges]
             edge_indices = self._medrecord.add_edges(edges)
 
             if group is None:
@@ -857,7 +793,7 @@ class MedRecord:
             if not self.contains_group(group):
                 self.add_group(group)
 
-            self.add_edge_to_group(group, edge_indices)
+            self.add_edges_to_group(group, edge_indices)
 
             return edge_indices
 
@@ -920,7 +856,7 @@ class MedRecord:
         if not self.contains_group(group):
             self.add_group(group)
 
-        self.add_edge_to_group(group, edge_indices)
+        self.add_edges_to_group(group, edge_indices)
 
         return edge_indices
 
@@ -970,7 +906,7 @@ class MedRecord:
         else:
             return self._medrecord.add_group(group, None, None)
 
-    def remove_group(self, group: Union[Group, GroupInputList]) -> None:
+    def remove_groups(self, group: Union[Group, GroupInputList]) -> None:
         """Removes one or more groups from the MedRecord instance.
 
         Args:
@@ -979,11 +915,11 @@ class MedRecord:
         Returns:
             None
         """
-        return self._medrecord.remove_group(
+        return self._medrecord.remove_groups(
             group if isinstance(group, list) else [group]
         )
 
-    def add_node_to_group(
+    def add_nodes_to_group(
         self, group: Group, node: Union[NodeIndex, NodeIndexInputList, NodeOperation]
     ) -> None:
         """Adds one or more nodes to a specified group in the MedRecord.
@@ -997,13 +933,13 @@ class MedRecord:
             None
         """
         if isinstance(node, NodeOperation):
-            return self._medrecord.add_node_to_group(group, self.select_nodes(node))
+            return self._medrecord.add_nodes_to_group(group, self.select_nodes(node))
 
-        return self._medrecord.add_node_to_group(
+        return self._medrecord.add_nodes_to_group(
             group, node if isinstance(node, list) else [node]
         )
 
-    def add_edge_to_group(
+    def add_edges_to_group(
         self, group: Group, edge: Union[EdgeIndex, EdgeIndexInputList, EdgeOperation]
     ) -> None:
         """Adds one or more edges to a specified group in the MedRecord.
@@ -1017,13 +953,13 @@ class MedRecord:
             None
         """
         if isinstance(edge, EdgeOperation):
-            return self._medrecord.add_edge_to_group(group, self.select_edges(edge))
+            return self._medrecord.add_edges_to_group(group, self.select_edges(edge))
 
-        return self._medrecord.add_edge_to_group(
+        return self._medrecord.add_edges_to_group(
             group, edge if isinstance(edge, list) else [edge]
         )
 
-    def remove_node_from_group(
+    def remove_nodes_from_group(
         self, group: Group, node: Union[NodeIndex, NodeIndexInputList, NodeOperation]
     ) -> None:
         """Removes one or more nodes from a specified group in the MedRecord.
@@ -1037,15 +973,15 @@ class MedRecord:
             None
         """
         if isinstance(node, NodeOperation):
-            return self._medrecord.remove_node_from_group(
+            return self._medrecord.remove_nodes_from_group(
                 group, self.select_nodes(node)
             )
 
-        return self._medrecord.remove_node_from_group(
+        return self._medrecord.remove_nodes_from_group(
             group, node if isinstance(node, list) else [node]
         )
 
-    def remove_edge_from_group(
+    def remove_edges_from_group(
         self, group: Group, edge: Union[EdgeIndex, EdgeIndexInputList, EdgeOperation]
     ) -> None:
         """Removes one or more edges from a specified group in the MedRecord.
@@ -1059,11 +995,11 @@ class MedRecord:
             None
         """
         if isinstance(edge, EdgeOperation):
-            return self._medrecord.remove_edge_from_group(
+            return self._medrecord.remove_edges_from_group(
                 group, self.select_edges(edge)
             )
 
-        return self._medrecord.remove_edge_from_group(
+        return self._medrecord.remove_edges_from_group(
             group, edge if isinstance(edge, list) else [edge]
         )
 

--- a/medmodels/medrecord/tests/test_builder.py
+++ b/medmodels/medrecord/tests/test_builder.py
@@ -58,10 +58,10 @@ class TestMedRecordBuilder(unittest.TestCase):
 
         medrecord = mr.MedRecord.builder().with_schema(schema).build()
 
-        medrecord.add_node("node", {"attribute": 1})
+        medrecord.add_nodes(("node1", {"attribute": 1}))
 
         with self.assertRaises(ValueError):
-            medrecord.add_node("node", {"attribute": "1"})
+            medrecord.add_nodes(("node2", {"attribute": "1"}))
 
 
 if __name__ == "__main__":

--- a/medmodels/medrecord/tests/test_medrecord.py
+++ b/medmodels/medrecord/tests/test_medrecord.py
@@ -262,33 +262,35 @@ class TestMedRecord(unittest.TestCase):
         medrecord = MedRecord.with_schema(schema)
         medrecord.add_group("group")
 
-        medrecord.add_node("0", {"attribute": 1})
+        medrecord.add_nodes(("0", {"attribute": 1}))
 
         with self.assertRaises(ValueError):
-            medrecord.add_node("1", {"attribute": "1"})
+            medrecord.add_nodes(("1", {"attribute": "1"}))
 
-        medrecord.add_node("1", {"attribute": 1, "attribute2": 1})
+        medrecord.add_nodes(("1", {"attribute": 1, "attribute2": 1}))
 
-        medrecord.add_node_to_group("group", "1")
+        medrecord.add_nodes_to_group("group", "1")
 
-        medrecord.add_node("2", {"attribute": 1, "attribute2": "1"})
-
-        with self.assertRaises(ValueError):
-            medrecord.add_node_to_group("group", "2")
-
-        medrecord.add_edge("0", "1", {"attribute": 1})
+        medrecord.add_nodes(("2", {"attribute": 1, "attribute2": "1"}))
 
         with self.assertRaises(ValueError):
-            medrecord.add_edge("0", "1", {"attribute": "1"})
+            medrecord.add_nodes_to_group("group", "2")
 
-        edge_index = medrecord.add_edge("0", "1", {"attribute": 1, "attribute2": 1})
-
-        medrecord.add_edge_to_group("group", edge_index)
-
-        edge_index = medrecord.add_edge("0", "1", {"attribute": 1, "attribute2": "1"})
+        medrecord.add_edges(("0", "1", {"attribute": 1}))
 
         with self.assertRaises(ValueError):
-            medrecord.add_edge_to_group("group", edge_index)
+            medrecord.add_edges(("0", "1", {"attribute": "1"}))
+
+        edge_index = medrecord.add_edges(("0", "1", {"attribute": 1, "attribute2": 1}))
+
+        medrecord.add_edges_to_group("group", edge_index)
+
+        edge_index = medrecord.add_edges(
+            ("0", "1", {"attribute": 1, "attribute2": "1"})
+        )
+
+        with self.assertRaises(ValueError):
+            medrecord.add_edges_to_group("group", edge_index)
 
     def test_nodes(self):
         medrecord = create_medrecord()
@@ -467,40 +469,17 @@ class TestMedRecord(unittest.TestCase):
 
         self.assertEqual([0, 1], sorted(edges))
 
-    def test_add_node(self):
-        medrecord = MedRecord()
-
-        self.assertEqual(0, medrecord.node_count())
-
-        medrecord.add_node("0", {})
-
-        self.assertEqual(1, medrecord.node_count())
-        self.assertEqual(0, len(medrecord.groups))
-
-        medrecord = MedRecord()
-
-        medrecord.add_node("0", {}, "0")
-
-        self.assertIn("0", medrecord.nodes_in_group("0"))
-        self.assertEqual(1, len(medrecord.groups))
-
-    def test_invalid_add_node(self):
-        medrecord = create_medrecord()
-
-        with self.assertRaises(AssertionError):
-            medrecord.add_node("0", {})
-
-    def test_remove_node(self):
+    def test_remove_nodes(self):
         medrecord = create_medrecord()
 
         self.assertEqual(4, medrecord.node_count())
 
-        attributes = medrecord.remove_node("0")
+        attributes = medrecord.remove_nodes("0")
 
         self.assertEqual(3, medrecord.node_count())
         self.assertEqual(create_nodes()[0][1], attributes)
 
-        attributes = medrecord.remove_node(["1", "2"])
+        attributes = medrecord.remove_nodes(["1", "2"])
 
         self.assertEqual(1, medrecord.node_count())
         self.assertEqual(
@@ -511,23 +490,23 @@ class TestMedRecord(unittest.TestCase):
 
         self.assertEqual(4, medrecord.node_count())
 
-        attributes = medrecord.remove_node(node_select().index().is_in(["0", "1"]))
+        attributes = medrecord.remove_nodes(node_select().index().is_in(["0", "1"]))
 
         self.assertEqual(2, medrecord.node_count())
         self.assertEqual(
             {"0": create_nodes()[0][1], "1": create_nodes()[1][1]}, attributes
         )
 
-    def test_invalid_remove_node(self):
+    def test_invalid_remove_nodes(self):
         medrecord = create_medrecord()
 
         # Removing a non-existing node should fail
         with self.assertRaises(IndexError):
-            medrecord.remove_node("50")
+            medrecord.remove_nodes("50")
 
         # Removing a non-existing node should fail
         with self.assertRaises(IndexError):
-            medrecord.remove_node(["0", "50"])
+            medrecord.remove_nodes(["0", "50"])
 
     def test_add_nodes(self):
         medrecord = MedRecord()
@@ -537,6 +516,23 @@ class TestMedRecord(unittest.TestCase):
         medrecord.add_nodes(create_nodes())
 
         self.assertEqual(4, medrecord.node_count())
+
+        # Adding node tuple
+        medrecord = MedRecord()
+
+        self.assertEqual(0, medrecord.node_count())
+
+        medrecord.add_nodes(("0", {}))
+
+        self.assertEqual(1, medrecord.node_count())
+        self.assertEqual(0, len(medrecord.groups))
+
+        medrecord = MedRecord()
+
+        medrecord.add_nodes(("0", {}), "0")
+
+        self.assertIn("0", medrecord.nodes_in_group("0"))
+        self.assertEqual(1, len(medrecord.groups))
 
         # Adding tuple to a group
         medrecord = MedRecord()
@@ -784,46 +780,17 @@ class TestMedRecord(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             medrecord.add_nodes_polars([(nodes, "index"), (second_nodes, "invalid")])
 
-    def test_add_edge(self):
+    def test_remove_edges(self):
         medrecord = create_medrecord()
 
         self.assertEqual(4, medrecord.edge_count())
 
-        medrecord.add_edge("0", "3", {})
-
-        self.assertEqual(5, medrecord.edge_count())
-
-        medrecord.add_edge("3", "0", {}, group="0")
-
-        self.assertEqual(6, medrecord.edge_count())
-        self.assertIn(5, medrecord.edges_in_group("0"))
-
-    def test_invalid_add_edge(self):
-        medrecord = MedRecord()
-
-        nodes = create_nodes()
-
-        medrecord.add_nodes(nodes)
-
-        # Adding an edge pointing to a non-existent node should fail
-        with self.assertRaises(IndexError):
-            medrecord.add_edge("0", "50", {})
-
-        # Adding an edge from a non-existing node should fail
-        with self.assertRaises(IndexError):
-            medrecord.add_edge("50", "0", {})
-
-    def test_remove_edge(self):
-        medrecord = create_medrecord()
-
-        self.assertEqual(4, medrecord.edge_count())
-
-        attributes = medrecord.remove_edge(0)
+        attributes = medrecord.remove_edges(0)
 
         self.assertEqual(3, medrecord.edge_count())
         self.assertEqual(create_edges()[0][2], attributes)
 
-        attributes = medrecord.remove_edge([1, 2])
+        attributes = medrecord.remove_edges([1, 2])
 
         self.assertEqual(1, medrecord.edge_count())
         self.assertEqual({1: create_edges()[1][2], 2: create_edges()[2][2]}, attributes)
@@ -832,17 +799,17 @@ class TestMedRecord(unittest.TestCase):
 
         self.assertEqual(4, medrecord.edge_count())
 
-        attributes = medrecord.remove_edge(edge_select().index().is_in([0, 1]))
+        attributes = medrecord.remove_edges(edge_select().index().is_in([0, 1]))
 
         self.assertEqual(2, medrecord.edge_count())
         self.assertEqual({0: create_edges()[0][2], 1: create_edges()[1][2]}, attributes)
 
-    def test_invalid_remove_edge(self):
+    def test_invalid_remove_edges(self):
         medrecord = create_medrecord()
 
         # Removing a non-existing edge should fail
         with self.assertRaises(IndexError):
-            medrecord.remove_edge(50)
+            medrecord.remove_edges(50)
 
     def test_add_edges(self):
         medrecord = MedRecord()
@@ -857,8 +824,21 @@ class TestMedRecord(unittest.TestCase):
 
         self.assertEqual(4, medrecord.edge_count())
 
-        # Adding tuple to a group
+        # Adding single edge tuple
+        medrecord = create_medrecord()
 
+        self.assertEqual(4, medrecord.edge_count())
+
+        medrecord.add_edges(("0", "3", {}))
+
+        self.assertEqual(5, medrecord.edge_count())
+
+        medrecord.add_edges(("3", "0", {}), group="0")
+
+        self.assertEqual(6, medrecord.edge_count())
+        self.assertIn(5, medrecord.edges_in_group("0"))
+
+        # Adding tuple to a group
         medrecord = MedRecord()
 
         medrecord.add_nodes(nodes)
@@ -983,6 +963,21 @@ class TestMedRecord(unittest.TestCase):
         self.assertIn(1, medrecord.edges_in_group("0"))
         self.assertIn(2, medrecord.edges_in_group("0"))
         self.assertIn(3, medrecord.edges_in_group("0"))
+
+    def test_invalid_add_edges(self):
+        medrecord = MedRecord()
+
+        nodes = create_nodes()
+
+        medrecord.add_nodes(nodes)
+
+        # Adding an edge pointing to a non-existent node should fail
+        with self.assertRaises(IndexError):
+            medrecord.add_edges(("0", "50", {}))
+
+        # Adding an edge from a non-existing node should fail
+        with self.assertRaises(IndexError):
+            medrecord.add_edges(("50", "0", {}))
 
     def test_add_edges_pandas(self):
         medrecord = MedRecord()
@@ -1140,141 +1135,141 @@ class TestMedRecord(unittest.TestCase):
         with self.assertRaises(AssertionError):
             medrecord.add_group("0", node_select().index() == "0")
 
-    def test_remove_group(self):
+    def test_remove_groups(self):
         medrecord = create_medrecord()
 
         medrecord.add_group("0")
 
         self.assertEqual(1, medrecord.group_count())
 
-        medrecord.remove_group("0")
+        medrecord.remove_groups("0")
 
         self.assertEqual(0, medrecord.group_count())
 
-    def test_invalid_remove_group(self):
+    def test_invalid_remove_groups(self):
         medrecord = create_medrecord()
 
         # Removing a non-existing group should fail
         with self.assertRaises(IndexError):
-            medrecord.remove_group("0")
+            medrecord.remove_groups("0")
 
-    def test_add_node_to_group(self):
+    def test_add_nodes_to_group(self):
         medrecord = create_medrecord()
 
         medrecord.add_group("0")
 
         self.assertEqual([], medrecord.nodes_in_group("0"))
 
-        medrecord.add_node_to_group("0", "0")
+        medrecord.add_nodes_to_group("0", "0")
 
         self.assertEqual(["0"], medrecord.nodes_in_group("0"))
 
-        medrecord.add_node_to_group("0", ["1", "2"])
+        medrecord.add_nodes_to_group("0", ["1", "2"])
 
         self.assertEqual(
             sorted(["0", "1", "2"]),
             sorted(medrecord.nodes_in_group("0")),
         )
 
-        medrecord.add_node_to_group("0", node_select().index() == "3")
+        medrecord.add_nodes_to_group("0", node_select().index() == "3")
 
         self.assertEqual(
             sorted(["0", "1", "2", "3"]),
             sorted(medrecord.nodes_in_group("0")),
         )
 
-    def test_invalid_add_node_to_group(self):
+    def test_invalid_add_nodes_to_group(self):
         medrecord = create_medrecord()
 
         medrecord.add_group("0", ["0"])
 
         # Adding to a non-existing group should fail
         with self.assertRaises(IndexError):
-            medrecord.add_node_to_group("50", "1")
+            medrecord.add_nodes_to_group("50", "1")
 
         # Adding to a non-existing group should fail
         with self.assertRaises(IndexError):
-            medrecord.add_node_to_group("50", ["1", "2"])
+            medrecord.add_nodes_to_group("50", ["1", "2"])
 
         # Adding a non-existing node to a group should fail
         with self.assertRaises(IndexError):
-            medrecord.add_node_to_group("0", "50")
+            medrecord.add_nodes_to_group("0", "50")
 
         # Adding a non-existing node to a group should fail
         with self.assertRaises(IndexError):
-            medrecord.add_node_to_group("0", ["1", "50"])
+            medrecord.add_nodes_to_group("0", ["1", "50"])
 
         # Adding a node to a group that already is in the group should fail
         with self.assertRaises(AssertionError):
-            medrecord.add_node_to_group("0", "0")
+            medrecord.add_nodes_to_group("0", "0")
 
         # Adding a node to a group that already is in the group should fail
         with self.assertRaises(AssertionError):
-            medrecord.add_node_to_group("0", ["1", "0"])
+            medrecord.add_nodes_to_group("0", ["1", "0"])
 
         # Adding a node to a group that already is in the group should fail
         with self.assertRaises(AssertionError):
-            medrecord.add_node_to_group("0", node_select().index() == "0")
+            medrecord.add_nodes_to_group("0", node_select().index() == "0")
 
-    def test_add_edge_to_group(self):
+    def test_add_edges_to_group(self):
         medrecord = create_medrecord()
 
         medrecord.add_group("0")
 
         self.assertEqual([], medrecord.edges_in_group("0"))
 
-        medrecord.add_edge_to_group("0", 0)
+        medrecord.add_edges_to_group("0", 0)
 
         self.assertEqual([0], medrecord.edges_in_group("0"))
 
-        medrecord.add_edge_to_group("0", [1, 2])
+        medrecord.add_edges_to_group("0", [1, 2])
 
         self.assertEqual(
             sorted([0, 1, 2]),
             sorted(medrecord.edges_in_group("0")),
         )
 
-        medrecord.add_edge_to_group("0", edge_select().index() == 3)
+        medrecord.add_edges_to_group("0", edge_select().index() == 3)
 
         self.assertEqual(
             sorted([0, 1, 2, 3]),
             sorted(medrecord.edges_in_group("0")),
         )
 
-    def test_invalid_add_edge_to_group(self):
+    def test_invalid_add_edges_to_group(self):
         medrecord = create_medrecord()
 
         medrecord.add_group("0", edges=[0])
 
         # Adding to a non-existing group should fail
         with self.assertRaises(IndexError):
-            medrecord.add_edge_to_group("50", 1)
+            medrecord.add_edges_to_group("50", 1)
 
         # Adding to a non-existing group should fail
         with self.assertRaises(IndexError):
-            medrecord.add_edge_to_group("50", [1, 2])
+            medrecord.add_edges_to_group("50", [1, 2])
 
         # Adding a non-existing edge to a group should fail
         with self.assertRaises(IndexError):
-            medrecord.add_edge_to_group("0", 50)
+            medrecord.add_edges_to_group("0", 50)
 
         # Adding a non-existing edge to a group should fail
         with self.assertRaises(IndexError):
-            medrecord.add_edge_to_group("0", [1, 50])
+            medrecord.add_edges_to_group("0", [1, 50])
 
         # Adding an edge to a group that already is in the group should fail
         with self.assertRaises(AssertionError):
-            medrecord.add_edge_to_group("0", 0)
+            medrecord.add_edges_to_group("0", 0)
 
         # Adding an edge to a group that already is in the group should fail
         with self.assertRaises(AssertionError):
-            medrecord.add_edge_to_group("0", [1, 0])
+            medrecord.add_edges_to_group("0", [1, 0])
 
         # Adding an edge to a group that already is in the group should fail
         with self.assertRaises(AssertionError):
-            medrecord.add_edge_to_group("0", edge_select().index() == 0)
+            medrecord.add_edges_to_group("0", edge_select().index() == 0)
 
-    def test_remove_node_from_group(self):
+    def test_remove_nodes_from_group(self):
         medrecord = create_medrecord()
 
         medrecord.add_group("0", ["0", "1"])
@@ -1284,58 +1279,58 @@ class TestMedRecord(unittest.TestCase):
             sorted(medrecord.nodes_in_group("0")),
         )
 
-        medrecord.remove_node_from_group("0", "1")
+        medrecord.remove_nodes_from_group("0", "1")
 
         self.assertEqual(["0"], medrecord.nodes_in_group("0"))
 
-        medrecord.add_node_to_group("0", "1")
+        medrecord.add_nodes_to_group("0", "1")
 
         self.assertEqual(
             sorted(["0", "1"]),
             sorted(medrecord.nodes_in_group("0")),
         )
 
-        medrecord.remove_node_from_group("0", ["0", "1"])
+        medrecord.remove_nodes_from_group("0", ["0", "1"])
 
         self.assertEqual([], medrecord.nodes_in_group("0"))
 
-        medrecord.add_node_to_group("0", ["0", "1"])
+        medrecord.add_nodes_to_group("0", ["0", "1"])
 
         self.assertEqual(
             sorted(["0", "1"]),
             sorted(medrecord.nodes_in_group("0")),
         )
 
-        medrecord.remove_node_from_group("0", node_select().index().is_in(["0", "1"]))
+        medrecord.remove_nodes_from_group("0", node_select().index().is_in(["0", "1"]))
 
         self.assertEqual([], medrecord.nodes_in_group("0"))
 
-    def test_invalid_remove_node_from_group(self):
+    def test_invalid_remove_nodes_from_group(self):
         medrecord = create_medrecord()
 
         medrecord.add_group("0", ["0", "1"])
 
         # Removing a node from a non-existing group should fail
         with self.assertRaises(IndexError):
-            medrecord.remove_node_from_group("50", "0")
+            medrecord.remove_nodes_from_group("50", "0")
 
         # Removing a node from a non-existing group should fail
         with self.assertRaises(IndexError):
-            medrecord.remove_node_from_group("50", ["0", "1"])
+            medrecord.remove_nodes_from_group("50", ["0", "1"])
 
         # Removing a node from a non-existing group should fail
         with self.assertRaises(IndexError):
-            medrecord.remove_node_from_group("50", node_select().index() == "0")
+            medrecord.remove_nodes_from_group("50", node_select().index() == "0")
 
         # Removing a non-existing node from a group should fail
         with self.assertRaises(IndexError):
-            medrecord.remove_node_from_group("0", "50")
+            medrecord.remove_nodes_from_group("0", "50")
 
         # Removing a non-existing node from a group should fail
         with self.assertRaises(IndexError):
-            medrecord.remove_node_from_group("0", ["0", "50"])
+            medrecord.remove_nodes_from_group("0", ["0", "50"])
 
-    def test_remove_edge_from_group(self):
+    def test_remove_edges_from_group(self):
         medrecord = create_medrecord()
 
         medrecord.add_group("0", edges=[0, 1])
@@ -1345,56 +1340,56 @@ class TestMedRecord(unittest.TestCase):
             sorted(medrecord.edges_in_group("0")),
         )
 
-        medrecord.remove_edge_from_group("0", 1)
+        medrecord.remove_edges_from_group("0", 1)
 
         self.assertEqual([0], medrecord.edges_in_group("0"))
 
-        medrecord.add_edge_to_group("0", 1)
+        medrecord.add_edges_to_group("0", 1)
 
         self.assertEqual(
             sorted([0, 1]),
             sorted(medrecord.edges_in_group("0")),
         )
 
-        medrecord.remove_edge_from_group("0", [0, 1])
+        medrecord.remove_edges_from_group("0", [0, 1])
 
         self.assertEqual([], medrecord.edges_in_group("0"))
 
-        medrecord.add_edge_to_group("0", [0, 1])
+        medrecord.add_edges_to_group("0", [0, 1])
 
         self.assertEqual(
             sorted([0, 1]),
             sorted(medrecord.edges_in_group("0")),
         )
 
-        medrecord.remove_edge_from_group("0", edge_select().index().is_in([0, 1]))
+        medrecord.remove_edges_from_group("0", edge_select().index().is_in([0, 1]))
 
         self.assertEqual([], medrecord.edges_in_group("0"))
 
-    def test_invalid_remove_edge_from_group(self):
+    def test_invalid_remove_edges_from_group(self):
         medrecord = create_medrecord()
 
         medrecord.add_group("0", edges=[0, 1])
 
         # Removing an edge from a non-existing group should fail
         with self.assertRaises(IndexError):
-            medrecord.remove_edge_from_group("50", 0)
+            medrecord.remove_edges_from_group("50", 0)
 
         # Removing an edge from a non-existing group should fail
         with self.assertRaises(IndexError):
-            medrecord.remove_edge_from_group("50", [0, 1])
+            medrecord.remove_edges_from_group("50", [0, 1])
 
         # Removing an edge from a non-existing group should fail
         with self.assertRaises(IndexError):
-            medrecord.remove_edge_from_group("50", edge_select().index() == 0)
+            medrecord.remove_edges_from_group("50", edge_select().index() == 0)
 
         # Removing a non-existing edge from a group should fail
         with self.assertRaises(IndexError):
-            medrecord.remove_edge_from_group("0", 50)
+            medrecord.remove_edges_from_group("0", 50)
 
         # Removing a non-existing edge from a group should fail
         with self.assertRaises(IndexError):
-            medrecord.remove_edge_from_group("0", [0, 50])
+            medrecord.remove_edges_from_group("0", [0, 50])
 
     def test_nodes_in_group(self):
         medrecord = create_medrecord()
@@ -1485,19 +1480,19 @@ class TestMedRecord(unittest.TestCase):
 
         self.assertEqual(0, medrecord.node_count())
 
-        medrecord.add_node("0", {})
+        medrecord.add_nodes([("0", {})])
 
         self.assertEqual(1, medrecord.node_count())
 
     def test_edge_count(self):
         medrecord = MedRecord()
 
-        medrecord.add_node("0", {})
-        medrecord.add_node("1", {})
+        medrecord.add_nodes(("0", {}))
+        medrecord.add_nodes(("1", {}))
 
         self.assertEqual(0, medrecord.edge_count())
 
-        medrecord.add_edge("0", "1", {})
+        medrecord.add_edges(("0", "1", {}))
 
         self.assertEqual(1, medrecord.edge_count())
 
@@ -1621,8 +1616,8 @@ class TestMedRecord(unittest.TestCase):
         self.assertEqual(medrecord.edge_count(), cloned_medrecord.edge_count())
         self.assertEqual(medrecord.group_count(), cloned_medrecord.group_count())
 
-        cloned_medrecord.add_node("new_node", {"attribute": "value"})
-        cloned_medrecord.add_edge("0", "new_node", {"attribute": "value"})
+        cloned_medrecord.add_nodes(("new_node", {"attribute": "value"}))
+        cloned_medrecord.add_edges(("0", "new_node", {"attribute": "value"}))
         cloned_medrecord.add_group("new_group", ["new_node"])
 
         self.assertNotEqual(medrecord.node_count(), cloned_medrecord.node_count())

--- a/medmodels/medrecord/types.py
+++ b/medmodels/medrecord/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Dict, List, Mapping, Tuple, TypedDict, Union
+from typing import TYPE_CHECKING, Dict, List, Mapping, Sequence, Tuple, TypedDict, Union
 
 import pandas as pd
 import polars as pl
@@ -86,6 +86,26 @@ PandasNodeDataFrameInput: TypeAlias = Tuple[pd.DataFrame, str]
 
 #: A type alias for input to a Pandas DataFrame for edges.
 PandasEdgeDataFrameInput: TypeAlias = Tuple[pd.DataFrame, str, str]
+
+#: A type alias for input to a node.
+NodeInput = Union[
+    NodeTuple,
+    Sequence[NodeTuple],
+    PandasNodeDataFrameInput,
+    List[PandasNodeDataFrameInput],
+    PolarsNodeDataFrameInput,
+    List[PolarsNodeDataFrameInput],
+]
+
+#: A type alias for input to an edge.
+EdgeInput = Union[
+    EdgeTuple,
+    Sequence[EdgeTuple],
+    PandasEdgeDataFrameInput,
+    List[PandasEdgeDataFrameInput],
+    PolarsEdgeDataFrameInput,
+    List[PolarsEdgeDataFrameInput],
+]
 
 
 class GroupInfo(TypedDict):

--- a/medmodels/treatment_effect/tests/test_temporal_analysis.py
+++ b/medmodels/treatment_effect/tests/test_temporal_analysis.py
@@ -150,9 +150,7 @@ class TestTreatmentEffect(unittest.TestCase):
         self.assertEqual(0, edge)
 
         # adding medication time
-        self.medrecord.add_edge(
-            source_node="M1", target_node="P1", attributes={"time": "2000-01-15"}
-        )
+        self.medrecord.add_edges(("M1", "P1", {"time": "2000-01-15"}))
 
         edge = find_reference_edge(
             self.medrecord,

--- a/rustmodels/src/medrecord/mod.rs
+++ b/rustmodels/src/medrecord/mod.rs
@@ -241,14 +241,7 @@ impl PyMedRecord {
             .collect()
     }
 
-    fn add_node(&mut self, node_index: PyNodeIndex, attributes: PyAttributes) -> PyResult<()> {
-        Ok(self
-            .0
-            .add_node(node_index.into(), attributes.deep_into())
-            .map_err(PyMedRecordError::from)?)
-    }
-
-    fn remove_node(
+    fn remove_nodes(
         &mut self,
         node_index: Vec<PyNodeIndex>,
     ) -> PyResult<HashMap<PyNodeIndex, PyAttributes>> {
@@ -349,23 +342,7 @@ impl PyMedRecord {
             .map_err(PyMedRecordError::from)?)
     }
 
-    fn add_edge(
-        &mut self,
-        source_node_index: PyNodeIndex,
-        target_node_index: PyNodeIndex,
-        attributes: PyAttributes,
-    ) -> PyResult<EdgeIndex> {
-        Ok(self
-            .0
-            .add_edge(
-                source_node_index.into(),
-                target_node_index.into(),
-                attributes.deep_into(),
-            )
-            .map_err(PyMedRecordError::from)?)
-    }
-
-    fn remove_edge(
+    fn remove_edges(
         &mut self,
         edge_index: Vec<EdgeIndex>,
     ) -> PyResult<HashMap<EdgeIndex, PyAttributes>> {
@@ -480,7 +457,7 @@ impl PyMedRecord {
             .map_err(PyMedRecordError::from)?)
     }
 
-    fn remove_group(&mut self, group: Vec<PyGroup>) -> PyResult<()> {
+    fn remove_groups(&mut self, group: Vec<PyGroup>) -> PyResult<()> {
         group.into_iter().try_for_each(|group| {
             self.0
                 .remove_group(&group)
@@ -490,7 +467,7 @@ impl PyMedRecord {
         })
     }
 
-    fn add_node_to_group(&mut self, group: PyGroup, node_index: Vec<PyNodeIndex>) -> PyResult<()> {
+    fn add_nodes_to_group(&mut self, group: PyGroup, node_index: Vec<PyNodeIndex>) -> PyResult<()> {
         node_index.into_iter().try_for_each(|node_index| {
             Ok(self
                 .0
@@ -499,7 +476,7 @@ impl PyMedRecord {
         })
     }
 
-    fn add_edge_to_group(&mut self, group: PyGroup, edge_index: Vec<EdgeIndex>) -> PyResult<()> {
+    fn add_edges_to_group(&mut self, group: PyGroup, edge_index: Vec<EdgeIndex>) -> PyResult<()> {
         edge_index.into_iter().try_for_each(|edge_index| {
             Ok(self
                 .0
@@ -508,7 +485,7 @@ impl PyMedRecord {
         })
     }
 
-    fn remove_node_from_group(
+    fn remove_nodes_from_group(
         &mut self,
         group: PyGroup,
         node_index: Vec<PyNodeIndex>,
@@ -521,7 +498,7 @@ impl PyMedRecord {
         })
     }
 
-    fn remove_edge_from_group(
+    fn remove_edges_from_group(
         &mut self,
         group: PyGroup,
         edge_index: Vec<EdgeIndex>,


### PR DESCRIPTION
Removed functions:
- `add_node`
- `add_edge`

Renamed functions:
- `remove_node` -> `remove_nodes`
- `remove_edge` -> `remove_edges`
- `remove_group` -> `remove_groups`
- `add_node_to_group` -> `add_nodes_to_group`
- `add_edge_to_group` -> `add_edges_to_group`
- `remove_node_from_group` -> `remove_nodes_from_group`
- `remove_edge_from_group` -> `remove_edges_from_group`

**For testing, a `make install-dev` action is required!**