### PR TITLE
fix: comparison operations now correctly evaluate operand

### DIFF
--- a/crates/medmodels-core/src/medrecord/querying/attributes/operation.rs
+++ b/crates/medmodels-core/src/medrecord/querying/attributes/operation.rs
@@ -74,7 +74,12 @@ macro_rules! get_single_attribute_comparison_operand_attribute {
 
                 let kind = &operand.kind;
 
-                get_single_operand_attribute!(kind, comparison_attributes)
+                let comparison_attributes =
+                    get_single_operand_attribute!(kind, comparison_attributes);
+
+                operand.evaluate($medrecord, comparison_attributes)?.ok_or(
+                    MedRecordError::QueryError("No attribute to compare".to_string()),
+                )?
             }
             SingleAttributeComparisonOperand::Attribute(attribute) => attribute.clone(),
         }
@@ -509,7 +514,8 @@ impl AttributesTreeOperation {
                 let comparison_attributes: Box<dyn Iterator<Item = (_, MedRecordAttribute)>> =
                     get_multiple_operand_attributes!(kind, comparison_attributes);
 
-                comparison_attributes
+                operand
+                    .evaluate(medrecord, comparison_attributes)?
                     .map(|(_, attribute)| attribute)
                     .collect::<Vec<_>>()
             }
@@ -998,10 +1004,11 @@ impl MultipleAttributesOperation {
                     .get_attributes(medrecord)?
                     .map(|attribute| (&0, attribute));
 
-                let attributes: Box<dyn Iterator<Item = (_, MedRecordAttribute)>> =
+                let comparison_attributes: Box<dyn Iterator<Item = (_, MedRecordAttribute)>> =
                     get_multiple_operand_attributes!(kind, comparison_attributes);
 
-                attributes
+                operand
+                    .evaluate(medrecord, comparison_attributes)?
                     .map(|(_, attribute)| attribute)
                     .collect::<Vec<_>>()
             }
@@ -1296,10 +1303,11 @@ impl SingleAttributeOperation {
                     .get_attributes(medrecord)?
                     .map(|attribute| (&0, attribute));
 
-                let attributes: Box<dyn Iterator<Item = (_, MedRecordAttribute)>> =
+                let comparison_attributes: Box<dyn Iterator<Item = (_, MedRecordAttribute)>> =
                     get_multiple_operand_attributes!(kind, comparison_attributes);
 
-                attributes
+                operand
+                    .evaluate(medrecord, comparison_attributes)?
                     .map(|(_, attribute)| attribute)
                     .collect::<Vec<_>>()
             }

--- a/crates/medmodels-core/src/medrecord/querying/edges/operation.rs
+++ b/crates/medmodels-core/src/medrecord/querying/edges/operation.rs
@@ -337,7 +337,9 @@ macro_rules! get_edge_index_comparison_operand_index {
 
                 let comparison_index = get_edge_index!(kind, comparison_indices);
 
-                comparison_index
+                operand.evaluate($medrecord, comparison_index)?.ok_or(
+                    MedRecordError::QueryError("No index to compare".to_string()),
+                )?
             }
             EdgeIndexComparisonOperand::Index(index) => index.clone(),
         }
@@ -552,7 +554,11 @@ impl EdgeIndicesOperation {
             EdgeIndicesComparisonOperand::Operand(operand) => {
                 let context = &operand.context;
 
-                context.evaluate(medrecord)?.cloned().collect::<Vec<_>>()
+                let comparison_indices = context.evaluate(medrecord)?.cloned();
+
+                operand
+                    .evaluate(medrecord, comparison_indices)?
+                    .collect::<Vec<_>>()
             }
             EdgeIndicesComparisonOperand::Indices(indices) => indices.clone(),
         };
@@ -708,7 +714,11 @@ impl EdgeIndexOperation {
             EdgeIndicesComparisonOperand::Operand(operand) => {
                 let context = &operand.context;
 
-                context.evaluate(medrecord)?.cloned().collect::<Vec<_>>()
+                let comparison_indices = context.evaluate(medrecord)?.cloned();
+
+                operand
+                    .evaluate(medrecord, comparison_indices)?
+                    .collect::<Vec<_>>()
             }
             EdgeIndicesComparisonOperand::Indices(indices) => indices.clone(),
         };

--- a/crates/medmodels-core/src/medrecord/querying/nodes/operation.rs
+++ b/crates/medmodels-core/src/medrecord/querying/nodes/operation.rs
@@ -397,7 +397,9 @@ macro_rules! get_node_index_comparison_operand {
 
                 let comparison_index = get_node_index!(kind, comparison_indices);
 
-                comparison_index
+                operand.evaluate($medrecord, comparison_index)?.ok_or(
+                    MedRecordError::QueryError("No index to compare".to_string()),
+                )?
             }
             NodeIndexComparisonOperand::Index(index) => index.clone(),
         }
@@ -693,7 +695,11 @@ impl NodeIndicesOperation {
             NodeIndicesComparisonOperand::Operand(operand) => {
                 let context = &operand.context;
 
-                context.evaluate(medrecord)?.cloned().collect::<Vec<_>>()
+                let comparison_indices = context.evaluate(medrecord)?.cloned();
+
+                operand
+                    .evaluate(medrecord, comparison_indices)?
+                    .collect::<Vec<_>>()
             }
             NodeIndicesComparisonOperand::Indices(indices) => indices.clone(),
         };
@@ -917,7 +923,11 @@ impl NodeIndexOperation {
             NodeIndicesComparisonOperand::Operand(operand) => {
                 let context = &operand.context;
 
-                context.evaluate(medrecord)?.cloned().collect::<Vec<_>>()
+                let comparison_indices = context.evaluate(medrecord)?.cloned();
+
+                operand
+                    .evaluate(medrecord, comparison_indices)?
+                    .collect::<Vec<_>>()
             }
             NodeIndicesComparisonOperand::Indices(indices) => indices.clone(),
         };

--- a/crates/medmodels-core/src/medrecord/querying/values/operation.rs
+++ b/crates/medmodels-core/src/medrecord/querying/values/operation.rs
@@ -60,7 +60,9 @@ macro_rules! get_single_value_comparison_operand_value {
 
                 let comparison_value = get_single_operand_value!(kind, comparison_values);
 
-                comparison_value
+                operand.evaluate($medrecord, comparison_value)?.ok_or(
+                    MedRecordError::QueryError("No index to compare".to_string()),
+                )?
             }
             SingleValueComparisonOperand::Value(value) => value.clone(),
         }
@@ -608,8 +610,14 @@ impl MultipleValuesOperation {
                 let context = &operand.context;
                 let attribute = operand.attribute.clone();
 
-                context
+                // TODO: This is a temporary solution. It should be optimized.
+                let comparison_values = context
                     .get_values(medrecord, attribute)?
+                    .map(|value| (&0, value));
+
+                operand
+                    .evaluate(medrecord, comparison_values)?
+                    .map(|(_, value)| value)
                     .collect::<Vec<_>>()
             }
             MultipleValuesComparisonOperand::Values(values) => values.clone(),
@@ -880,8 +888,14 @@ impl SingleValueOperation {
                 let context = &operand.context;
                 let attribute = operand.attribute.clone();
 
-                context
+                // TODO: This is a temporary solution. It should be optimized.
+                let comparison_values = context
                     .get_values(medrecord, attribute)?
+                    .map(|value| (&0, value));
+
+                operand
+                    .evaluate(medrecord, comparison_values)?
+                    .map(|(_, value)| value)
                     .collect::<Vec<_>>()
             }
             MultipleValuesComparisonOperand::Values(values) => values.clone(),


### PR DESCRIPTION
This fixes a bug where operations that change the value of an operand (e.g. `.add(...)`, `.subtract(...)`, `.round()` etc.) are not applied correctly when the operand is used in a comparison