### PR TITLE
refactor: optimize treatment effect and associated functions with new query engine

### DIFF
--- a/medmodels/treatment_effect/estimate.py
+++ b/medmodels/treatment_effect/estimate.py
@@ -164,10 +164,13 @@ class Estimate:
                 MedRecord (patients, treatments, outcomes).
         """
         self._check_medrecord(medrecord=medrecord)
-        treatment_true, treatment_false, control_true, control_false = (
-            self._treatment_effect._find_groups(medrecord)
-        )
-        treated_group = treatment_true | treatment_false
+        (
+            treated_outcome_true,
+            treated_outcome_false,
+            control_outcome_true,
+            control_outcome_false,
+        ) = self._treatment_effect._find_groups(medrecord)
+        treated_set = treated_outcome_true | treated_outcome_false
 
         if self._treatment_effect._matching_method:
             matching: Matching = (
@@ -182,22 +185,29 @@ class Estimate:
                 )
             )
 
-            control_group = control_true | control_false
+            control_set = control_outcome_true | control_outcome_false
 
             matched_controls = matching.match_controls(
                 medrecord=medrecord,
-                treated_group=treated_group,
-                control_group=control_group,
+                treated_set=treated_set,
+                control_set=control_set,
                 essential_covariates=self._treatment_effect._matching_essential_covariates,
                 one_hot_covariates=self._treatment_effect._matching_one_hot_covariates,
             )
-            control_true, control_false = self._treatment_effect._find_controls(
-                medrecord=medrecord,
-                control_group=matched_controls,
-                treated_group=treated_group,
+            control_outcome_true, control_outcome_false = (
+                self._treatment_effect._find_controls(
+                    medrecord=medrecord,
+                    control_set=matched_controls,
+                    treated_set=treated_set,
+                )
             )
 
-        return treatment_true, treatment_false, control_true, control_false
+        return (
+            treated_outcome_true,
+            treated_outcome_false,
+            control_outcome_true,
+            control_outcome_false,
+        )
 
     def _compute_subject_counts(
         self, medrecord: MedRecord

--- a/medmodels/treatment_effect/matching/matching.py
+++ b/medmodels/treatment_effect/matching/matching.py
@@ -26,8 +26,8 @@ class Matching(metaclass=ABCMeta):
         self,
         *,
         medrecord: MedRecord,
-        control_group: Set[NodeIndex],
-        treated_group: Set[NodeIndex],
+        control_set: Set[NodeIndex],
+        treated_set: Set[NodeIndex],
         essential_covariates: MedRecordAttributeInputList,
         one_hot_covariates: MedRecordAttributeInputList,
     ) -> Tuple[pl.DataFrame, pl.DataFrame]:
@@ -35,8 +35,8 @@ class Matching(metaclass=ABCMeta):
 
         Args:
             medrecord (MedRecord):  MedRecord object containing the data.
-            control_group (Set[NodeIndex]): Set of treated subjects.
-            treated_group (Set[NodeIndex]): Set of control subjects.
+            control_set (Set[NodeIndex]): Set of treated subjects.
+            treated_set (Set[NodeIndex]): Set of control subjects.
             essential_covariates (MedRecordAttributeInputList):  Covariates
                 that are essential for matching
             one_hot_covariates (MedRecordAttributeInputList): Covariates that
@@ -55,7 +55,7 @@ class Matching(metaclass=ABCMeta):
         data = pl.DataFrame(
             data=[
                 {"id": k, **v}
-                for k, v in medrecord.node[list(control_group | treated_group)].items()
+                for k, v in medrecord.node[list(control_set | treated_set)].items()
             ]
         )
         original_columns = data.columns
@@ -74,8 +74,8 @@ class Matching(metaclass=ABCMeta):
         data = data.select(essential_covariates)
 
         # Select the sets of treated and control subjects
-        data_treated = data.filter(pl.col("id").is_in(treated_group))
-        data_control = data.filter(pl.col("id").is_in(control_group))
+        data_treated = data.filter(pl.col("id").is_in(treated_set))
+        data_control = data.filter(pl.col("id").is_in(control_set))
 
         return data_treated, data_control
 
@@ -83,8 +83,8 @@ class Matching(metaclass=ABCMeta):
     def match_controls(
         self,
         *,
-        control_group: Set[NodeIndex],
-        treated_group: Set[NodeIndex],
+        control_set: Set[NodeIndex],
+        treated_set: Set[NodeIndex],
         medrecord: MedRecord,
         essential_covariates: MedRecordAttributeInputList = ["gender", "age"],
         one_hot_covariates: MedRecordAttributeInputList = ["gender"],

--- a/medmodels/treatment_effect/matching/neighbors.py
+++ b/medmodels/treatment_effect/matching/neighbors.py
@@ -38,8 +38,8 @@ class NeighborsMatching(Matching):
         self,
         *,
         medrecord: MedRecord,
-        control_group: Set[NodeIndex],
-        treated_group: Set[NodeIndex],
+        control_set: Set[NodeIndex],
+        treated_set: Set[NodeIndex],
         essential_covariates: MedRecordAttributeInputList = ["gender", "age"],
         one_hot_covariates: MedRecordAttributeInputList = ["gender"],
     ) -> Set[NodeIndex]:
@@ -47,8 +47,8 @@ class NeighborsMatching(Matching):
 
         Args:
             medrecord (MedRecord): MedRecord object containing the data.
-            treated_group (Set[NodeIndex]): Set of treated subjects.
-            control_group (Set[NodeIndex]): Set of control subjects.
+            treated_set (Set[NodeIndex]): Set of treated subjects.
+            control_set (Set[NodeIndex]): Set of control subjects.
             essential_covariates (MedRecordAttributeInputList, optional): Covariates
                 that are essential for matching
             one_hot_covariates (MedRecordAttributeInputList, optional): Covariates that
@@ -59,8 +59,8 @@ class NeighborsMatching(Matching):
         """
         data_treated, data_control = self._preprocess_data(
             medrecord=medrecord,
-            control_group=control_group,
-            treated_group=treated_group,
+            control_set=control_set,
+            treated_set=treated_set,
             essential_covariates=essential_covariates,
             one_hot_covariates=one_hot_covariates,
         )

--- a/medmodels/treatment_effect/matching/propensity.py
+++ b/medmodels/treatment_effect/matching/propensity.py
@@ -58,8 +58,8 @@ class PropensityMatching(Matching):
         self,
         *,
         medrecord: MedRecord,
-        control_group: Set[NodeIndex],
-        treated_group: Set[NodeIndex],
+        control_set: Set[NodeIndex],
+        treated_set: Set[NodeIndex],
         essential_covariates: MedRecordAttributeInputList = ["gender", "age"],
         one_hot_covariates: MedRecordAttributeInputList = ["gender"],
     ) -> Set[NodeIndex]:
@@ -67,8 +67,8 @@ class PropensityMatching(Matching):
 
         Args:
             medrecord (MedRecord): medrecord object containing the data.
-            treated_group (Set[NodeIndex]): Set of treated subjects.
-            control_group (Set[NodeIndex]): Set of control subjects.
+            treated_set (Set[NodeIndex]): Set of treated subjects.
+            control_set (Set[NodeIndex]): Set of control subjects.
             essential_covariates (MedRecordAttributeInputList, optional): Covariates
                 that are essential for matching. Defaults to ["gender", "age"].
             one_hot_covariates (MedRecordAttributeInputList, optional): Covariates that
@@ -80,8 +80,8 @@ class PropensityMatching(Matching):
         # Preprocess the data
         data_treated, data_control = self._preprocess_data(
             medrecord=medrecord,
-            treated_group=treated_group,
-            control_group=control_group,
+            treated_set=treated_set,
+            control_set=control_set,
             essential_covariates=essential_covariates,
             one_hot_covariates=one_hot_covariates,
         )

--- a/medmodels/treatment_effect/temporal_analysis.py
+++ b/medmodels/treatment_effect/temporal_analysis.py
@@ -1,8 +1,7 @@
 from typing import Literal
 
-import pandas as pd
-
 from medmodels.medrecord.medrecord import MedRecord
+from medmodels.medrecord.querying import EdgeOperand
 from medmodels.medrecord.types import EdgeIndex, Group, MedRecordAttribute, NodeIndex
 
 
@@ -13,7 +12,7 @@ def find_reference_edge(
     reference: Literal["first", "last"],
     time_attribute: MedRecordAttribute = "time",
 ) -> EdgeIndex:
-    """Determines the reference edge that represents the first or last exposure of a node index to any node in the connecte_group (list of nodes).
+    """Determines the reference edge that represents the first or last exposure of a node index to any node in the connected_group (list of nodes).
 
     This method is crucial for analyzing the temporal sequence of treatments and outcomes.
 
@@ -38,10 +37,8 @@ def find_reference_edge(
         EdgeIndex: The edge index of the reference exposure.
 
     Raises:
-        ValueError: If no edge with a time attribute is found for the node, indicating
-            an issue with the data or the connection to the specified nodes.
-        ValueError: If no edge is found for the specified node with the nodes in that
-            group in the MedRecord.
+        ValueError: If no edge with that time attribute or datetime datatype found for
+            the node in this MedRecord.
 
     Example:
         This function returns the edge containing the timestamp of the last exposure to any
@@ -58,127 +55,47 @@ def find_reference_edge(
             )
 
     """
-    if reference == "first":
-        reference_time = pd.Timestamp.max
-    elif reference == "last":
-        reference_time = pd.Timestamp.min
 
-    nodes_in_group = medrecord.nodes_in_group(connected_group)
-    reference_edge = None
+    def query_source_node(edge: EdgeOperand) -> None:
+        """Query the source node of an edge to have a specific index and the target node to be in a specified group.
 
-    for node_from_group in nodes_in_group:
-        edges = medrecord.edges_connecting(node_index, node_from_group, directed=False)
+        Args:
+            edge (EdgeOperand): The edge operand.
+        """
+        edge.source_node().index().equal_to(node_index)
+        edge.target_node().in_group(connected_group)
 
-        # If the node does not have an edge to that node, continue
-        if not edges:
-            continue
+    def query_target_node(edge: EdgeOperand) -> None:
+        """Query the source node of an edge to be in a specified group and the target node to have a specific index.
 
-        # If the node has an edge, check if it has the time attribute
-        edge_values = medrecord.edge[edges].values()
+        Args:
+            edge (EdgeOperand): The edge operand.
+        """
+        edge.source_node().in_group(connected_group)
+        edge.target_node().index().equal_to(node_index)
 
-        if not all(time_attribute in edge_attribute for edge_attribute in edge_values):
-            raise ValueError("Time attribute not found in the edge attributes")
+    def query(edge: EdgeOperand) -> None:
+        """Query the edge that connects the group to the node and has the minimum or maximum time attribute.
 
-        for edge in edges:
-            edge_time = pd.to_datetime(str(medrecord.edge[edge][time_attribute]))
+        Args:
+            edge (EdgeOperand): The edge operand.
+        """
+        edge.either_or(query_source_node, query_target_node)
+        edge.attribute(time_attribute).is_datetime()
 
-            if (reference == "first" and edge_time < reference_time) or (
-                reference == "last" and edge_time > reference_time
-            ):
-                reference_edge = edge
-                reference_time = edge_time
+        if reference == "first":
+            edge.attribute(time_attribute).is_min()
+        elif reference == "last":
+            edge.attribute(time_attribute).is_max()
 
-    if reference_edge is None:
-        raise ValueError(f"No edge found for node {node_index} in this MedRecord")
+    try:
+        reference_edge = medrecord.select_edges(query)
 
-    return reference_edge
+    except RuntimeError:
+        msg = (
+            f"No edge with that time attribute or with a datetime data type was found for node "
+            f"{node_index} in this MedRecord"
+        )
+        raise ValueError(msg)
 
-
-def find_node_in_time_window(
-    medrecord: MedRecord,
-    subject_index: NodeIndex,
-    event_node: NodeIndex,
-    connected_group: Group,
-    start_days: int,
-    end_days: int,
-    reference: Literal["first", "last"],
-    time_attribute: MedRecordAttribute = "time",
-) -> bool:
-    """Determines whether an event occurred within a specified time window for a given subject node.
-
-    This method helps in identifying events that are temporally related to a reference
-    event by considering the temporal sequence of events.
-
-    Args:
-        medrecord (MedRecord): An instance of the MedRecord class containing medical
-            data.
-        subject_index (NodeIndex): The subject node to evaluate.
-        event_node (NodeIndex): The event node to check for its occurrence within the
-            time window.
-        connected_group (Group): The group of nodes that are connected to the subject
-            node.
-        start_days (int): The start of the time window in days relative to the
-            reference event.
-        end_days (int): The end of the time window in days relative to the
-            reference event.
-        reference (Literal["first", "last"]): The reference point for the time
-            window.
-        time_attribute (MedRecordAttribute, optional): The attribute in the edge that
-            contains the time information. Defaults to "time".
-
-    Returns:
-        bool: True if the event occurred within the specified time window;
-            False otherwise.
-
-    Raises:
-        ValueError: If the time attribute is not found in the edge attributes.
-
-    Examples:
-        This function checks if the event "E1" occurred within a time window of 30 days
-        before and after the last exposure to any medication in the group "medications" for
-        the subject "P1":
-
-        .. code-block:: python
-            :linenos:
-
-            find_node_in_time_window(
-                medrecord,
-                subject_index="P1",
-                event_node="E1",
-                connected_group="medications",
-                start_days=-30,
-                end_days=30,
-                reference="last",
-            )
-
-        .. code-block:: python
-
-            >>> True
-    """
-    reference_edge = find_reference_edge(
-        medrecord,
-        subject_index,
-        connected_group,
-        reference=reference,
-        time_attribute=time_attribute,
-    )
-    reference_time = pd.to_datetime(str(medrecord.edge[reference_edge][time_attribute]))
-
-    start_period = pd.Timedelta(days=start_days)
-    end_period = pd.Timedelta(days=end_days)
-    edges = medrecord.edges_connecting(subject_index, event_node, directed=False)
-
-    for edge in edges:
-        edge_attributes = medrecord.edge[edge]
-        if time_attribute not in edge_attributes:
-            raise ValueError("Time attribute not found in the edge attributes")
-
-        event_time = pd.to_datetime(str(edge_attributes[time_attribute]))
-        time_difference = event_time - reference_time
-
-        # Return True if the event happened within the specified time window
-        if start_period <= time_difference <= end_period:
-            return True
-
-    # Return False if no event happened within the time window
-    return False
+    return reference_edge[0]

--- a/medmodels/treatment_effect/tests/test_continuous_estimators.py
+++ b/medmodels/treatment_effect/tests/test_continuous_estimators.py
@@ -1,6 +1,7 @@
 """Tests for the TreatmentEffect class in the treatment_effect module."""
 
 import unittest
+from datetime import datetime
 from typing import List
 
 import pandas as pd
@@ -98,13 +99,13 @@ def create_edges1(patient_list: List[NodeIndex]) -> pd.DataFrame:
                 "P9",
             ],
             "time": [
-                "1999-10-15",
-                "2000-01-01",
-                "1999-12-15",
-                "2000-01-01",
-                "2000-01-01",
-                "2000-01-01",
-                "2000-01-01",
+                datetime(1999, 10, 15),
+                datetime(2000, 1, 1),
+                datetime(1999, 12, 15),
+                datetime(2000, 1, 1),
+                datetime(2000, 1, 1),
+                datetime(2000, 1, 1),
+                datetime(2000, 1, 1),
             ],
         }
     )
@@ -137,12 +138,12 @@ def create_edges2(patient_list: List[NodeIndex]) -> pd.DataFrame:
                 "P7",
             ],
             "time": [
-                "2000-01-01",
-                "2000-07-01",
-                "1999-12-15",
-                "2000-01-05",
-                "2000-01-01",
-                "2000-01-01",
+                datetime.strptime("2000-01-01", "%Y-%m-%d"),
+                datetime.strptime("2000-07-01", "%Y-%m-%d"),
+                datetime.strptime("1999-12-15", "%Y-%m-%d"),
+                datetime.strptime("2000-01-05", "%Y-%m-%d"),
+                datetime.strptime("2000-01-01", "%Y-%m-%d"),
+                datetime.strptime("2000-01-01", "%Y-%m-%d"),
             ],
             "intensity": [
                 0.1,

--- a/medmodels/treatment_effect/tests/test_temporal_analysis.py
+++ b/medmodels/treatment_effect/tests/test_temporal_analysis.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime
 from typing import List
 
 import pandas as pd
@@ -6,7 +7,6 @@ import pandas as pd
 from medmodels.medrecord.medrecord import MedRecord
 from medmodels.medrecord.types import NodeIndex
 from medmodels.treatment_effect.temporal_analysis import (
-    find_node_in_time_window,
     find_reference_edge,
 )
 
@@ -86,11 +86,11 @@ def create_edges(patient_list: List[NodeIndex]) -> pd.DataFrame:
                 "P3",
             ],
             "time": [
-                "2000-01-01",
-                "2000-01-01",
-                "2000-01-01",
-                "1999-12-15",
-                "2000-07-01",
+                datetime(2000, 1, 1),
+                datetime(2000, 1, 1),
+                datetime(2000, 1, 1),
+                datetime(1999, 12, 15),
+                datetime(2000, 7, 1),
             ],
         }
     )
@@ -134,7 +134,7 @@ def create_medrecord(
     return medrecord
 
 
-class TestTreatmentEffect(unittest.TestCase):
+class TestTemporalAnalysis(unittest.TestCase):
     """"""
 
     def setUp(self):
@@ -150,7 +150,7 @@ class TestTreatmentEffect(unittest.TestCase):
         self.assertEqual(0, edge)
 
         # adding medication time
-        self.medrecord.add_edges(("M1", "P1", {"time": "2000-01-15"}))
+        self.medrecord.add_edges(("M1", "P1", {"time": datetime(2000, 1, 15)}))
 
         edge = find_reference_edge(
             self.medrecord,
@@ -170,7 +170,8 @@ class TestTreatmentEffect(unittest.TestCase):
 
     def test_invalid_find_reference_time(self):
         with self.assertRaisesRegex(
-            ValueError, "Time attribute not found in the edge attributes"
+            ValueError,
+            "No edge with that time attribute or with a datetime data type was found for node P1 in this MedRecord",
         ):
             find_reference_edge(
                 self.medrecord,
@@ -182,7 +183,8 @@ class TestTreatmentEffect(unittest.TestCase):
 
         node_index = "P2"
         with self.assertRaisesRegex(
-            ValueError, f"No edge found for node {node_index} in this MedRecord"
+            ValueError,
+            "No edge with that time attribute or with a datetime data type was found for node P2 in this MedRecord",
         ):
             find_reference_edge(
                 self.medrecord,
@@ -192,49 +194,7 @@ class TestTreatmentEffect(unittest.TestCase):
                 time_attribute="time",
             )
 
-    def test_node_in_time_window(self):
-        # check if patient has outcome a year after treatment
-        node_found = find_node_in_time_window(
-            self.medrecord,
-            subject_index="P3",
-            event_node="D1",
-            connected_group="Rivaroxaban",
-            start_days=0,
-            end_days=365,
-            reference="last",
-            time_attribute="time",
-        )
-        self.assertTrue(node_found)
-
-        # check if patient has outcome 30 days after treatment
-        node_found2 = find_node_in_time_window(
-            self.medrecord,
-            subject_index="P3",
-            connected_group="Rivaroxaban",
-            event_node="D1",
-            start_days=0,
-            end_days=30,
-            reference="last",
-            time_attribute="time",
-        )
-        self.assertFalse(node_found2)
-
-    def test_invalid_node_in_time_window(self):
-        with self.assertRaisesRegex(
-            ValueError, "Time attribute not found in the edge attributes"
-        ):
-            find_node_in_time_window(
-                self.medrecord,
-                subject_index="P3",
-                connected_group="Rivaroxaban",
-                event_node="D1",
-                start_days=0,
-                end_days=30,
-                reference="last",
-                time_attribute="no_time",
-            )
-
 
 if __name__ == "__main__":
-    run_test = unittest.TestLoader().loadTestsFromTestCase(TestTreatmentEffect)
+    run_test = unittest.TestLoader().loadTestsFromTestCase(TestTemporalAnalysis)
     unittest.TextTestRunner(verbosity=2).run(run_test)

--- a/medmodels/treatment_effect/treatment_effect.py
+++ b/medmodels/treatment_effect/treatment_effect.py
@@ -11,6 +11,7 @@ to treatment groups using a specified matching class.
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 from typing import Any, Dict, Literal, Optional, Set, Tuple
 
 from medmodels import MedRecord
@@ -26,7 +27,6 @@ from medmodels.treatment_effect.estimate import Estimate
 from medmodels.treatment_effect.matching.algorithms.propensity_score import Model
 from medmodels.treatment_effect.matching.matching import MatchingMethod
 from medmodels.treatment_effect.report import Report
-from medmodels.treatment_effect.temporal_analysis import find_node_in_time_window
 
 
 class TreatmentEffect:
@@ -143,12 +143,20 @@ class TreatmentEffect:
                 neighbors to match for each treated subject. Defaults to 1.
             matching_hyperparam (Optional[Dict[str, Any]], optional): The
                 hyperparameters for the matching model. Defaults to None.
+
+        Raises:
+            ValueError: If the follow-up period is less than the grace period.
         """
         treatment_effect._patients_group = patients_group
         treatment_effect._time_attribute = time_attribute
 
         treatment_effect._treatments_group = treatment
         treatment_effect._outcomes_group = outcome
+
+        if follow_up_period_days < grace_period_days:
+            raise ValueError(
+                "The follow-up period must be greater than or equal to the grace period."
+            )
 
         treatment_effect._washout_period_days = washout_period_days
         treatment_effect._washout_period_reference = washout_period_reference
@@ -189,28 +197,26 @@ class TreatmentEffect:
                 (control_outcome_false).
         """
         # Find patients that underwent the treatment
-        treated_group = self._find_treated_patients(medrecord)
-        treated_group, washout_nodes = self._apply_washout_period(
-            medrecord, treated_group
+        treated_set = self._find_treated_patients(medrecord)
+        treated_set, washout_nodes = self._apply_washout_period(medrecord, treated_set)
+        treated_set, treated_outcome_true, outcome_before_treatment_nodes = (
+            self._find_outcomes(medrecord, treated_set)
         )
-        treated_group, treated_outcome_true, outcome_before_treatment_nodes = (
-            self._find_outcomes(medrecord, treated_group)
-        )
-        treatment_outcome_false = treated_group - treated_outcome_true
+        treated_outcome_false = treated_set - treated_outcome_true
 
         # Find the controls (patients that did not undergo the treatment)
-        control_group = set(medrecord.nodes_in_group(self._patients_group))
+        control_set = set(medrecord.nodes_in_group(self._patients_group))
         control_outcome_true, control_outcome_false = self._find_controls(
             medrecord=medrecord,
-            control_group=control_group,
-            treated_group=treated_group,
+            control_set=control_set,
+            treated_set=treated_set,
             rejected_nodes=washout_nodes | outcome_before_treatment_nodes,
             filter_controls_query=self._filter_controls_query,
         )
 
         return (
             treated_outcome_true,
-            treatment_outcome_false,
+            treated_outcome_false,
             control_outcome_true,
             control_outcome_false,
         )
@@ -229,29 +235,23 @@ class TreatmentEffect:
             ValueError: If no patients are found for the treatment groups in the
                 MedRecord.
         """
-        treated_group = set()
-
-        treatments = medrecord.nodes_in_group(self._treatments_group)
 
         def query(node: NodeOperand):
             node.in_group(self._patients_group)
-
-            node.neighbors(edge_direction=EdgeDirection.BOTH).index().equal_to(
-                treatment
+            node.neighbors(edge_direction=EdgeDirection.BOTH).in_group(
+                self._treatments_group
             )
 
-        # Create the group with all the patients that underwent the treatment
-        for treatment in treatments:
-            treated_group.update(set(medrecord.select_nodes(query)))
-        if not treated_group:
+        treated_set = set(medrecord.select_nodes(query))
+        if not treated_set:
             raise ValueError(
                 "No patients found for the treatment groups in this MedRecord."
             )
 
-        return treated_group
+        return treated_set
 
     def _find_outcomes(
-        self, medrecord: MedRecord, treated_group: Set[NodeIndex]
+        self, medrecord: MedRecord, treated_set: Set[NodeIndex]
     ) -> Tuple[Set[NodeIndex], Set[NodeIndex], Set[NodeIndex]]:
         """Find the patients that had the outcome after the treatment.
 
@@ -261,7 +261,7 @@ class TreatmentEffect:
         Args:
             medrecord (MedRecord): An instance of the MedRecord class containing patient
                 medical data.
-            treated_group (Set[NodeIndex]): A set of patient nodes that underwent the
+            treated_set (Set[NodeIndex]): A set of patient nodes that underwent the
                 treatment.
 
         Returns:
@@ -275,8 +275,8 @@ class TreatmentEffect:
             ValueError: If no outcomes are found in the MedRecord for the specified
                 outcome group.
         """
-        treatment_outcome_true = set()
         outcome_before_treatment_nodes = set()
+        outcome_before_treatment_days = self._outcome_before_treatment_days
 
         # Find nodes with the outcomes
         outcomes = medrecord.nodes_in_group(self._outcomes_group)
@@ -285,70 +285,51 @@ class TreatmentEffect:
                 f"No outcomes found in the MedRecord for group {self._outcomes_group}"
             )
 
-        def query(node: NodeOperand):
-            node.index().is_in(list(treated_group))
-
-            # This could probably be refactored to a proper query
-            node.neighbors(edge_direction=EdgeDirection.BOTH).index().equal_to(outcome)
-
-        for outcome in outcomes:
-            nodes_to_check = set(medrecord.select_nodes(query))
-
-            # Find patients that had the outcome before the treatment
-            if self._outcome_before_treatment_days:
-                outcome_before_treatment_nodes.update(
-                    {
-                        node_index
-                        for node_index in nodes_to_check
-                        if find_node_in_time_window(
-                            medrecord,
-                            node_index,
-                            outcome,
-                            connected_group=self._treatments_group,
-                            start_days=-self._outcome_before_treatment_days,
-                            end_days=0,
-                            reference="first",
-                        )
-                    }
-                )
-                nodes_to_check -= outcome_before_treatment_nodes
-
-            # Find patients that had the outcome after the treatment
-            treatment_outcome_true.update(
-                {
-                    node_index
-                    for node_index in nodes_to_check
-                    if find_node_in_time_window(
-                        medrecord,
-                        node_index,
-                        outcome,
-                        connected_group=self._treatments_group,
-                        start_days=self._grace_period_days,
-                        end_days=self._follow_up_period_days,
-                        reference=self._follow_up_period_reference,
+        if outcome_before_treatment_days:
+            outcome_before_treatment_nodes = set(
+                medrecord.select_nodes(
+                    lambda node: self._query_node_within_time_window(
+                        node,
+                        treated_set,
+                        self._outcomes_group,
+                        -outcome_before_treatment_days,
+                        0,
+                        "first",
                     )
-                }
+                )
             )
+            treated_set -= outcome_before_treatment_nodes
 
-        treated_group -= outcome_before_treatment_nodes
-        if outcome_before_treatment_nodes:
             dropped_num = len(outcome_before_treatment_nodes)
             logging.warning(
                 f"{dropped_num} subject{' was' if dropped_num == 1 else 's were'} "
                 f"dropped due to outcome before treatment."
             )
 
-        return treated_group, treatment_outcome_true, outcome_before_treatment_nodes
+        treated_outcome_true = set(
+            medrecord.select_nodes(
+                lambda node: self._query_node_within_time_window(
+                    node,
+                    treated_set,
+                    self._outcomes_group,
+                    self._grace_period_days,
+                    self._follow_up_period_days,
+                    self._follow_up_period_reference,
+                )
+            )
+        )
+
+        return treated_set, treated_outcome_true, outcome_before_treatment_nodes
 
     def _apply_washout_period(
-        self, medrecord: MedRecord, treated_group: Set[NodeIndex]
+        self, medrecord: MedRecord, treated_set: Set[NodeIndex]
     ) -> Tuple[Set[NodeIndex], Set[NodeIndex]]:
         """Apply the washout period to the treatment group.
 
         Args:
             medrecord (MedRecord): An instance of the MedRecord class containing patient
                 medical data.
-            treated_group (Set[NodeIndex]): A set of patient nodes that underwent the
+            treated_set (Set[NodeIndex]): A set of patient nodes that underwent the
                 treatment.
 
         Returns:
@@ -358,29 +339,24 @@ class TreatmentEffect:
         """
         washout_nodes = set()
         if not self._washout_period_days:
-            return treated_group, washout_nodes
+            return treated_set, washout_nodes
 
         # Apply the washout period to the treatment group
         # TODO: washout in both directions? We need a List then
         for washout_group_id, washout_days in self._washout_period_days.items():
-            for washout_node in medrecord.nodes_in_group(washout_group_id):
-                washout_nodes.update(
-                    {
-                        treated_node
-                        for treated_node in treated_group
-                        if find_node_in_time_window(
-                            medrecord,
-                            treated_node,
-                            washout_node,
-                            connected_group=self._treatments_group,
-                            start_days=-washout_days,
-                            end_days=0,
-                            reference=self._washout_period_reference,
-                        )
-                    }
+            washout_nodes.update(
+                medrecord.select_nodes(
+                    lambda node: self._query_node_within_time_window(
+                        node,
+                        treated_set,
+                        washout_group_id,
+                        -washout_days,
+                        0,
+                        self._washout_period_reference,
+                    )
                 )
-
-                treated_group -= washout_nodes
+            )
+            treated_set -= washout_nodes
 
         if washout_nodes:
             dropped_num = len(washout_nodes)
@@ -388,13 +364,14 @@ class TreatmentEffect:
                 f"{dropped_num} subject{' was' if dropped_num == 1 else 's were'} "
                 f"dropped due to outcome before treatment."
             )
-        return treated_group, washout_nodes
+
+        return treated_set, washout_nodes
 
     def _find_controls(
         self,
         medrecord: MedRecord,
-        control_group: Set[NodeIndex],
-        treated_group: Set[NodeIndex],
+        control_set: Set[NodeIndex],
+        treated_set: Set[NodeIndex],
         rejected_nodes: Set[NodeIndex] = set(),
         filter_controls_query: Optional[NodeQuery] = None,
     ) -> Tuple[Set[NodeIndex], Set[NodeIndex]]:
@@ -410,9 +387,9 @@ class TreatmentEffect:
         Args:
             medrecord (MedRecord): An instance of the MedRecord class containing patient
                 medical data.
-            control_group (Set[NodeIndex]): A set of patient nodes that did not undergo
+            control_set (Set[NodeIndex]): A set of patient nodes that did not undergo
                 the treatment.
-            treated_group (Set[NodeIndex]): A set of patient nodes that underwent the
+            treated_set (Set[NodeIndex]): A set of patient nodes that underwent the
                 treatment.
             rejected_nodes (Set[NodeIndex]): A set of patient nodes that were rejected
                 due to the washout period or outcome before treatment.
@@ -434,16 +411,15 @@ class TreatmentEffect:
         """
         # Apply the filter to the control group if specified
         if filter_controls_query:
-            control_group = (
-                set(medrecord.select_nodes(filter_controls_query)) & control_group
+            control_set = (
+                set(medrecord.select_nodes(filter_controls_query)) & control_set
             )
 
-        control_group = control_group - treated_group - rejected_nodes
-        if len(control_group) == 0:
+        control_set = control_set - treated_set - rejected_nodes
+        if len(control_set) == 0:
             raise ValueError("No patients found for control groups in this MedRecord.")
 
         control_outcome_true = set()
-        control_outcome_false = set()
         outcomes = medrecord.nodes_in_group(self._outcomes_group)
         if not outcomes:
             raise ValueError(
@@ -451,17 +427,85 @@ class TreatmentEffect:
             )
 
         def query(node: NodeOperand):
-            node.index().is_in(list(control_group))
-
-            node.neighbors(edge_direction=EdgeDirection.BOTH).index().equal_to(outcome)
+            node.index().is_in(list(control_set))
+            node.neighbors(edge_direction=EdgeDirection.BOTH).in_group(
+                self._outcomes_group
+            )
 
         # Finding the patients that had the outcome in the control group
-        for outcome in outcomes:
-            control_outcome_true.update(medrecord.select_nodes(query))
-
-        control_outcome_false = control_group - control_outcome_true
+        control_outcome_true = set(medrecord.select_nodes(query))
+        control_outcome_false = control_set - control_outcome_true
 
         return control_outcome_true, control_outcome_false
+
+    def _query_node_within_time_window(
+        self,
+        node: NodeOperand,
+        treated_set: Set[NodeIndex],
+        outcome_group: Group,
+        start_days: int,
+        end_days: int,
+        reference: Literal["first", "last"],
+    ) -> None:
+        """Queries for nodes with edges containing time information within a specified time window.
+
+        It queries for nodes that:
+            - Are in the treated group.
+            - Have edges with time information.
+            - Have edges that connect to the treatment group.
+            - Have edges that connect to the outcome group.
+            - The time of the outcome is within the specified time window: it being
+                greater or equal than the first or last time of treatment (depending on
+                the `reference`) and less or equal than the time of treatment plus the
+                `end_days` specified.
+
+        Args:
+            node (NodeOperand): The node to query.
+            treated_set (Set[NodeIndex]): A set of patient nodes that underwent the
+                treatment.
+            start_days (int): The start of the time window in days relative to the
+                reference event.
+            end_days (int): The end of the time window in days relative to the reference
+                event.
+            reference (Literal["first", "last"]): The reference point for the time window.
+        """
+        node.index().is_in(list(treated_set))
+
+        edges_to_treatment = node.edges()
+        edges_to_treatment.attribute(self._time_attribute).is_datetime()
+        edges_to_treatment.either_or(
+            lambda edge: edge.source_node().in_group(self._treatments_group),
+            lambda edge: edge.target_node().in_group(self._treatments_group),
+        )
+
+        edges_to_outcome = node.edges()
+        edges_to_outcome.attribute(self._time_attribute).is_datetime()
+        edges_to_outcome.either_or(
+            lambda edge: edge.source_node().in_group(outcome_group),
+            lambda edge: edge.target_node().in_group(outcome_group),
+        )
+
+        if reference == "first":
+            time_of_treatment = edges_to_treatment.attribute(self._time_attribute).min()
+        else:
+            time_of_treatment = edges_to_treatment.attribute(self._time_attribute).max()
+
+        time_of_outcome = edges_to_outcome.attribute(self._time_attribute)
+
+        min_time_window = time_of_treatment.clone()
+        if start_days < 0:
+            min_time_window.subtract(timedelta(-start_days))
+        else:
+            min_time_window.add(timedelta(start_days))
+
+        max_time_window = time_of_treatment.clone()
+        if end_days < 0:
+            max_time_window.subtract(timedelta(-end_days))
+        else:
+            max_time_window.add(timedelta(end_days))
+
+        time_of_outcome.greater_than_or_equal_to(min_time_window)
+        time_of_outcome.less_than_or_equal_to(max_time_window)
 
     @property
     def estimate(self) -> Estimate:


### PR DESCRIPTION
- Eliminated `find_node_in_time_window` (not needed anymore in that format) and refactored into the `TreatmentEffect` class as "_query_node_within_time_window".
- Changed "treated_group" and "control_group" variables into "treated_set" and "control_set" in all TEE files since they might lead to confusion. Also, changed a couple variable names that should have been changed in previous PRs but were forgotten.
- Changed datatypes and error messages in tests for new query.

Note:
    - Some errors used as sanity checks were eliminated from the TreatmentEffect because of the implementation of the Query Engine. These should be re-implemented after issue #100 