### PR TITLE
fix: linting and docstrings issues in treatment effect module

### DIFF
--- a/medmodels/medrecord/medrecord.py
+++ b/medmodels/medrecord/medrecord.py
@@ -564,7 +564,7 @@ class MedRecord:
         if isinstance(target_node, Callable):
             target_node = self.select_nodes(target_node)
 
-        if directed:
+        if directed == EdgesDirected.DIRECTED:
             return self._medrecord.edges_connecting(
                 (source_node if isinstance(source_node, list) else [source_node]),
                 (target_node if isinstance(target_node, list) else [target_node]),

--- a/medmodels/treatment_effect/builder.py
+++ b/medmodels/treatment_effect/builder.py
@@ -1,8 +1,4 @@
-"""This module contains the TreatmentEffectBuilder class.
-
-The TreatmentEffectBuilder class is used to build a TreatmentEffect object with the
-desired configurations for the treatment effect estimation using a builder pattern.
-"""
+"""This module contains the TreatmentEffectBuilder class."""
 
 from __future__ import annotations
 
@@ -24,8 +20,9 @@ if TYPE_CHECKING:
 class TreatmentEffectBuilder:
     """Builder class for the TreatmentEffect object.
 
-    The TreatmentEffectBuilder class is used to build a TreatmentEffect object with the
-    desired configurations for the treatment effect estimation using a builder pattern.
+    The TreatmentEffectBuilder class is used to build a TreatmentEffect object with
+    the desired configurations for the treatment effect estimation using a builder
+    pattern.
     """
 
     treatment: Group

--- a/medmodels/treatment_effect/builder.py
+++ b/medmodels/treatment_effect/builder.py
@@ -1,3 +1,9 @@
+"""This module contains the TreatmentEffectBuilder class.
+
+The TreatmentEffectBuilder class is used to build a TreatmentEffect object with the
+desired configurations for the treatment effect estimation using a builder pattern.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, Literal, Optional
@@ -16,6 +22,12 @@ if TYPE_CHECKING:
 
 
 class TreatmentEffectBuilder:
+    """Builder class for the TreatmentEffect object.
+
+    The TreatmentEffectBuilder class is used to build a TreatmentEffect object with the
+    desired configurations for the treatment effect estimation using a builder pattern.
+    """
+
     treatment: Group
     outcome: Group
 
@@ -40,7 +52,7 @@ class TreatmentEffectBuilder:
     matching_one_hot_covariates: Optional[MedRecordAttributeInputList]
     matching_model: Optional[Model]
     matching_number_of_neighbors: Optional[int]
-    matching_hyperparam: Optional[Dict[str, Any]]
+    matching_hyperparameters: Optional[Dict[str, Any]]
 
     def with_treatment(self, treatment: Group) -> TreatmentEffectBuilder:
         """Sets the treatment group for the treatment effect estimation.
@@ -106,8 +118,8 @@ class TreatmentEffectBuilder:
     ) -> TreatmentEffectBuilder:
         """Sets the washout period for the treatment effect estimation.
 
-        The washout period is the period of time before the treatment that is not considered in the
-        estimation.
+        The washout period is the period of time before the treatment that is not
+        considered in the estimation.
 
         Args:
             days (Optional[Dict[str, int]], optional): The duration of the washout
@@ -135,8 +147,8 @@ class TreatmentEffectBuilder:
     ) -> TreatmentEffectBuilder:
         """Sets the grace period for the treatment effect estimation.
 
-        The grace period is the period of time after the treatment that is not considered in the
-        estimation.
+        The grace period is the period of time after the treatment that is not
+        considered in the estimation.
 
         Args:
             days (Optional[int], optional): The duration of the grace period in days.
@@ -220,58 +232,59 @@ class TreatmentEffectBuilder:
 
     def with_propensity_matching(
         self,
-        essential_covariates: MedRecordAttributeInputList = None,
-        one_hot_covariates: MedRecordAttributeInputList = None,
+        essential_covariates: Optional[MedRecordAttributeInputList] = None,
+        one_hot_covariates: Optional[MedRecordAttributeInputList] = None,
         model: Model = "logit",
         number_of_neighbors: int = 1,
-        hyperparam: Optional[Dict[str, Any]] = None,
+        hyperparameters: Optional[Dict[str, Any]] = None,
     ) -> TreatmentEffectBuilder:
         """Adjust the treatment effect estimate using propensity score matching.
 
         Args:
-            essential_covariates (MedRecordAttributeInputList, optional):
+            essential_covariates (Optional[MedRecordAttributeInputList], optional):
                 Covariates that are essential for matching. Defaults to
                 ["gender", "age"].
-            one_hot_covariates (MedRecordAttributeInputList, optional):
+            one_hot_covariates (Optional[MedRecordAttributeInputList], optional):
                 Covariates that are one-hot encoded for matching. Defaults to
                 ["gender"].
             model (Model, optional): Model to choose for the matching. Defaults to
                 "logit".
             number_of_neighbors (int, optional): Number of neighbors to consider
                 for the matching. Defaults to 1.
-            hyperparam (Optional[Dict[str, Any]], optional): Hyperparameters for the
-                matching model. Defaults to None.
+            hyperparameters (Optional[Dict[str, Any]], optional): Hyperparameters for
+                the matching model. Defaults to None.
 
         Returns:
             TreatmentEffectBuilder: The current instance of the TreatmentEffectBuilder
                 with updated matching configurations.
         """
-        if one_hot_covariates is None:
-            one_hot_covariates = ["gender"]
         if essential_covariates is None:
             essential_covariates = ["gender", "age"]
+        if one_hot_covariates is None:
+            one_hot_covariates = ["gender"]
+
         self.matching_method = "propensity"
         self.matching_essential_covariates = essential_covariates
         self.matching_one_hot_covariates = one_hot_covariates
         self.matching_model = model
         self.matching_number_of_neighbors = number_of_neighbors
-        self.matching_hyperparam = hyperparam
+        self.matching_hyperparameters = hyperparameters
 
         return self
 
     def with_nearest_neighbors_matching(
         self,
-        essential_covariates: MedRecordAttributeInputList = None,
-        one_hot_covariates: MedRecordAttributeInputList = None,
+        essential_covariates: Optional[MedRecordAttributeInputList] = None,
+        one_hot_covariates: Optional[MedRecordAttributeInputList] = None,
         number_of_neighbors: int = 1,
     ) -> TreatmentEffectBuilder:
         """Adjust the treatment effect estimate using nearest neighbors matching.
 
         Args:
-            essential_covariates (MedRecordAttributeInputList, optional):
+            essential_covariates (Optional[MedRecordAttributeInputList], optional):
                 Covariates that are essential for matching. Defaults to
                 ["gender", "age"].
-            one_hot_covariates (MedRecordAttributeInputList, optional):
+            one_hot_covariates (Optional[MedRecordAttributeInputList], optional):
                 Covariates that are one-hot encoded for matching. Defaults to
                 ["gender"].
             number_of_neighbors (int, optional): Number of neighbors to consider for the
@@ -281,10 +294,11 @@ class TreatmentEffectBuilder:
             TreatmentEffectBuilder: The current instance of the TreatmentEffectBuilder
                 with updated matching configurations.
         """
-        if one_hot_covariates is None:
-            one_hot_covariates = ["gender"]
         if essential_covariates is None:
             essential_covariates = ["gender", "age"]
+        if one_hot_covariates is None:
+            one_hot_covariates = ["gender"]
+
         self.matching_method = "nearest_neighbors"
         self.matching_essential_covariates = essential_covariates
         self.matching_one_hot_covariates = one_hot_covariates

--- a/medmodels/treatment_effect/continuous_estimators.py
+++ b/medmodels/treatment_effect/continuous_estimators.py
@@ -10,6 +10,8 @@ from medmodels.medrecord.medrecord import MedRecord
 from medmodels.medrecord.types import Group, MedRecordAttribute, NodeIndex
 from medmodels.treatment_effect.temporal_analysis import find_reference_edge
 
+logger = logging.getLogger(__name__)
+
 
 def average_treatment_effect(
     medrecord: MedRecord,
@@ -195,7 +197,7 @@ def cohens_d(
     minimum_length = min(len(treated_outcomes), len(control_outcomes))
 
     if minimum_length < 50:
-        logging.warning(
+        logger.warning(
             "Small sample size detected. Consider using Hedges' g for an unbiased effect size estimate."
         )
 
@@ -283,19 +285,15 @@ def hedges_g(
     number_control = len(control_outcomes)
     degrees_of_freedom = number_treated + number_control - 2
 
-    # Calculate pooled standard deviation
-    treated_std_dev = treated_outcomes.std(ddof=1)
-    control_std_dev = control_outcomes.std(ddof=1)
-    pooled_std_dev = sqrt(
-        (
-            (number_treated - 1) * treated_std_dev**2
-            + (number_control - 1) * control_std_dev**2
-        )
-        / degrees_of_freedom
+    cohen_d = cohens_d(
+        medrecord,
+        treatment_outcome_true_set,
+        control_outcome_true_set,
+        outcome_group,
+        outcome_variable,
+        reference,
+        time_attribute,
     )
-
-    # Calculate Cohen's d
-    cohen_d = (treated_outcomes.mean() - control_outcomes.mean()) / pooled_std_dev
 
     # Correction factor J
     correction_factor_j = 1 - (3 / (4 * degrees_of_freedom - 1))

--- a/medmodels/treatment_effect/continuous_estimators.py
+++ b/medmodels/treatment_effect/continuous_estimators.py
@@ -1,3 +1,6 @@
+"""Functions to estimate the treatment effect for continuous outcomes."""
+
+import logging
 from math import sqrt
 from typing import Literal, Set
 
@@ -17,9 +20,11 @@ def average_treatment_effect(
     reference: Literal["first", "last"] = "last",
     time_attribute: MedRecordAttribute = "time",
 ) -> float:
-    r"""Calculates the Average Treatment Effect (ATE) as the difference between the outcome means of the treated and control sets.
+    r"""Calculates the Average Treatment Effect (ATE).
 
-    A positive ATE indicates that the treatment increased the outcome, while a negative ATE suggests a decrease.
+    It is calculated as the difference between the outcome means of the treated and
+    control sets. A positive ATE indicates that the treatment increased the outcome,
+    while a negative ATE suggests a decrease.
 
     The ATE is computed as follows when the numbers of observations in treated and
     control sets are N and M, respectively:
@@ -28,9 +33,9 @@ def average_treatment_effect(
 
         \\text{ATE} = \\frac{1}{N} \\sum_i y_1(i) - \\frac{1}{M} \\sum_j y_0(j),
 
-    where :math:`y_1(i)` and :math:`y_0(j)` represent outcome values for individual treated and
-    control observations. In the case of matched sets with equal sizes (N = M), the
-    formula simplifies to:
+    where :math:`y_1(i)` and :math:`y_0(j)` represent outcome values for individual
+    treated and control observations. In the case of matched sets with equal sizes
+    (N = M), the formula simplifies to:
 
     .. math::
 
@@ -84,7 +89,7 @@ def average_treatment_effect(
                     medrecord,
                     node_index,
                     outcome_group,
-                    time_attribute="time",
+                    time_attribute=time_attribute,
                     reference=reference,
                 )
             ][outcome_variable]
@@ -106,25 +111,21 @@ def cohens_d(
     outcome_variable: MedRecordAttribute,
     reference: Literal["first", "last"] = "last",
     time_attribute: MedRecordAttribute = "time",
-    add_correction: bool = False,
 ) -> float:
-    """Calculates Cohen's D, the standardized mean difference between two sets, measuring the effect size of the difference between two outcome means.
+    """Calculates Cohen's D, the standardized mean difference between two sets.
 
-    It's applicable for any two sets but is recommended for sets of the same size. Cohen's D indicates how
-    many standard deviations the two groups differ by, with 1 standard deviation equal
-    to 1 z-score.
+    This measures the effect size of the difference between two outcome means.
+    It's applicable for any two sets but is recommended for sets of the same size.
+    Cohen's D indicates how many standard deviations the two groups differ by, with 1
+    standard deviation equal to 1 z-score.
 
-    The correction factor is applied when the sample size is small, as the standard
-    deviation of the sample is not an accurate estimate of the population standard
-    deviation, using Hedges' g formula instead.
+    A rule of thumb for interpreting Cohen's D:
+    - Small effect = ±0.2
+    - Medium effect = ±0.5
+    - Large effect = ±0.8
 
-    A rule of thumb for interpreting Cohen's D
-    - Small effect = +-0.2
-    - Medium effect = +-0.5
-    - Large effect = +-0.8
-
-    If the difference is negative, indicated the mean in the treated group is lower than
-    the control group.
+    If the difference is negative, it indicates the mean in the treated group is lower
+    than the control group.
 
     This metric provides a dimensionless measure of effect size, facilitating the
     comparison across different studies and contexts.
@@ -145,12 +146,99 @@ def cohens_d(
             latest exposure edge. Defaults to "last".
         time_attribute (MedRecordAttribute, optional): The attribute in the edge that
             contains the time information. Defaults to "time".
-        add_correction (bool, optional): Whether to apply a correction factor for small
-            sample sizes. When True, using Hedges' g formula instead of Cohens' D.
-            Defaults to False.
 
     Returns:
         float: The Cohen's D coefficient, representing the effect size.
+
+    Raises:
+        ValueError: If the outcome variable is not numeric.
+
+    Warning:
+        If the sample size is small (less than 50), the function advises Hedges' g use.
+    """
+    treated_outcomes = np.array(
+        [
+            medrecord.edge[
+                find_reference_edge(
+                    medrecord,
+                    node_index,
+                    outcome_group,
+                    time_attribute=time_attribute,
+                    reference=reference,
+                )
+            ][outcome_variable]
+            for node_index in treatment_outcome_true_set
+        ]
+    )
+    if not all(isinstance(i, (int, float)) for i in treated_outcomes):
+        msg = "Outcome variable must be numeric"
+        raise ValueError(msg)
+
+    control_outcomes = np.array(
+        [
+            medrecord.edge[
+                find_reference_edge(
+                    medrecord,
+                    node_index,
+                    outcome_group,
+                    time_attribute=time_attribute,
+                    reference=reference,
+                )
+            ][outcome_variable]
+            for node_index in control_outcome_true_set
+        ]
+    )
+    if not all(isinstance(i, (int, float)) for i in control_outcomes):
+        msg = "Outcome variable must be numeric"
+        raise ValueError(msg)
+
+    minimum_length = min(len(treated_outcomes), len(control_outcomes))
+
+    if minimum_length < 50:
+        logging.warning(
+            "Small sample size detected. Consider using Hedges' g for an unbiased effect size estimate."
+        )
+
+    return (treated_outcomes.mean() - control_outcomes.mean()) / sqrt(
+        (treated_outcomes.std(ddof=1) ** 2 + control_outcomes.std(ddof=1) ** 2) / 2
+    )
+
+
+def hedges_g(
+    medrecord: MedRecord,
+    treatment_outcome_true_set: Set[NodeIndex],
+    control_outcome_true_set: Set[NodeIndex],
+    outcome_group: Group,
+    outcome_variable: MedRecordAttribute,
+    reference: Literal["first", "last"] = "last",
+    time_attribute: MedRecordAttribute = "time",
+) -> float:
+    """Calculates Hedges' g, the unbiased effect size estimate.
+
+    Hedges' g is a corrected version of Cohen's d that provides an unbiased estimate
+    of the effect size, especially important when sample sizes are small (under 50).
+
+    The correction factor is applied regardless of the sample size.
+
+    Args:
+        medrecord (MedRecord): An instance of the MedRecord class containing medical
+            data.
+        treatment_outcome_true_set (Set[NodeIndex]): A set of node indices representing
+            the treated group that also have the outcome.
+        control_outcome_true_set (Set[NodeIndex]): A set of node indices representing
+            the control group that have the outcome.
+        outcome_group (Group): The group of nodes that contain the outcome variable.
+        outcome_variable (MedRecordAttribute): The attribute in the edge that contains
+            the outcome variable. It must be numeric and continuous.
+        reference (Literal["first", "last"], optional): The reference point for the
+            exposure time. Options include "first" and "last". If "first", the function
+            returns the earliest exposure edge. If "last", the function returns the
+            latest exposure edge. Defaults to "last".
+        time_attribute (MedRecordAttribute, optional): The attribute in the edge that
+            contains the time information. Defaults to "time".
+
+    Returns:
+        float: The Hedges' g coefficient, representing the effect size.
 
     Raises:
         ValueError: If the outcome variable is not numeric.
@@ -180,7 +268,7 @@ def cohens_d(
                     medrecord,
                     node_index,
                     outcome_group,
-                    time_attribute="time",
+                    time_attribute=time_attribute,
                     reference=reference,
                 )
             ][outcome_variable]
@@ -191,23 +279,32 @@ def cohens_d(
         msg = "Outcome variable must be numeric"
         raise ValueError(msg)
 
-    min_len = min(len(treated_outcomes), len(control_outcomes))
-    cf = 1  # correction factor
+    number_treated = len(treated_outcomes)
+    number_control = len(control_outcomes)
+    degrees_of_freedom = number_treated + number_control - 2
 
-    if min_len < 50:
-        # correction factor for small sample sizes, using Hedges' g formula instead
-        # TODO: logging asking to use Hedges'g formula instead
-        if add_correction:
-            cf = (min_len - 3) * sqrt((min_len - 2) / min_len) / (min_len - 2.25)
-
-    return (
-        (treated_outcomes.mean() - control_outcomes.mean())
-        * cf
-        / sqrt((treated_outcomes.std() ** 2 + control_outcomes.std() ** 2) / 2)
+    # Calculate pooled standard deviation
+    treated_std_dev = treated_outcomes.std(ddof=1)
+    control_std_dev = control_outcomes.std(ddof=1)
+    pooled_std_dev = sqrt(
+        (
+            (number_treated - 1) * treated_std_dev**2
+            + (number_control - 1) * control_std_dev**2
+        )
+        / degrees_of_freedom
     )
+
+    # Calculate Cohen's d
+    cohen_d = (treated_outcomes.mean() - control_outcomes.mean()) / pooled_std_dev
+
+    # Correction factor J
+    correction_factor_j = 1 - (3 / (4 * degrees_of_freedom - 1))
+
+    return correction_factor_j * cohen_d
 
 
 CONTINUOUS_ESTIMATOR = {
     "average_te": average_treatment_effect,
     "cohens_d": cohens_d,
+    "hedges_g": hedges_g,
 }

--- a/medmodels/treatment_effect/estimate.py
+++ b/medmodels/treatment_effect/estimate.py
@@ -1,3 +1,5 @@
+"""Estimators class for calculating treatment effect metrics."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, Set, Tuple, TypedDict
@@ -5,6 +7,7 @@ from typing import TYPE_CHECKING, Literal, Set, Tuple, TypedDict
 from medmodels.treatment_effect.continuous_estimators import (
     average_treatment_effect,
     cohens_d,
+    hedges_g,
 )
 from medmodels.treatment_effect.matching.neighbors import NeighborsMatching
 from medmodels.treatment_effect.matching.propensity import PropensityMatching
@@ -16,7 +19,18 @@ if TYPE_CHECKING:
     from medmodels.treatment_effect.treatment_effect import TreatmentEffect
 
 
+class SubjectIndices(TypedDict):
+    """Dictionary with the patient ids of all contingency table groups."""
+
+    treated_outcome_true: Set[NodeIndex]
+    treated_outcome_false: Set[NodeIndex]
+    control_outcome_true: Set[NodeIndex]
+    control_outcome_false: Set[NodeIndex]
+
+
 class ContingencyTable:
+    """Contingency table for the treatment and control groups with/without outcome."""
+
     number_treated_outcome_true: int
     number_treated_outcome_false: int
     number_control_outcome_true: int
@@ -28,7 +42,7 @@ class ContingencyTable:
         number_treated_outcome_false: int,
         number_control_outcome_true: int,
         number_control_outcome_false: int,
-    ):
+    ) -> None:
         """Initializes the ContingencyTable object.
 
         It stores the number of patients in the treatment and control groups with and
@@ -49,7 +63,7 @@ class ContingencyTable:
         self.number_control_outcome_true = number_control_outcome_true
         self.number_control_outcome_false = number_control_outcome_false
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Returns a string representation of the ContingencyTable object.
 
         The contingency table provides an overview of the number of subjects in the
@@ -89,32 +103,27 @@ class ContingencyTable:
             "control_outcome_false",
         ],
     ) -> int:
-        """Returns the number of subjects in the treatment and control groups with and without the outcome.
+        """Returns the number of subjects in the given group.
 
         Args:
-            key (Literal["treated_outcome_true", "treated_outcome_false",
-                "control_outcome_true", "control_outcome_false"]): The key to access the
-                number of subjects in the treatment and control groups with and without
-                the outcome.
+            key (Literal["treated_outcome_true", "treated_outcome_false", "control_outcome_true", "control_outcome_false"]):
+                The key to access the number of subjects in the treatment and control
+                groups with and without the outcome.
 
         Returns:
             int: Number of subject in the selected group.
-        """
+        """  # noqa: W505
         completed_key = "number_" + key
         return getattr(self, completed_key)
 
 
-class SubjectIndices(TypedDict):
-    treated_outcome_true: Set[NodeIndex]
-    treated_outcome_false: Set[NodeIndex]
-    control_outcome_true: Set[NodeIndex]
-    control_outcome_false: Set[NodeIndex]
-
-
 class Estimate:
+    """Estimators class for calculating treatment effect metrics."""
+
     _treatment_effect: TreatmentEffect
 
     def __init__(self, treatment_effect: TreatmentEffect) -> None:
+        """Initializes the Estimate object."""
         self._treatment_effect = treatment_effect
 
     def _check_medrecord(self, medrecord: MedRecord) -> None:
@@ -149,7 +158,10 @@ class Estimate:
     def _sort_subjects_in_groups(
         self, medrecord: MedRecord
     ) -> Tuple[Set[NodeIndex], Set[NodeIndex], Set[NodeIndex], Set[NodeIndex]]:
-        """Sorts subjects into the contingency table of treatment-outcome, treatment-no outcome, control-outcome and control-no outcome.
+        """Sorts subjects into the different groups of the contingency table.
+
+        This means, sorting the subjects into treatment-outcome, treatment-no outcome,
+        control-outcome and control-no outcome.
 
         The treatment group and control matching is determined based on the treatment
         effect configuration.
@@ -161,10 +173,6 @@ class Estimate:
             Tuple[Set[NodeIndex], Set[NodeIndex], Set[NodeIndex], Set[NodeIndex]: The
                 patient ids of true and false subjects in the treatment and control
                 groups, respectively.
-
-        Raises:
-            ValueError: Raises Error if the required groups are not present in the
-                MedRecord (patients, treatments, outcomes).
         """
         self._check_medrecord(medrecord=medrecord)
         treatment_true, treatment_false, control_true, control_false = (
@@ -181,7 +189,7 @@ class Estimate:
                 else PropensityMatching(
                     number_of_neighbors=self._treatment_effect._matching_number_of_neighbors,
                     model=self._treatment_effect._matching_model,
-                    hyperparam=self._treatment_effect._matching_hyperparam,
+                    hyperparam=self._treatment_effect._matching_hyperparameters,
                 )
             )
 
@@ -230,15 +238,17 @@ class Estimate:
         ) = self._sort_subjects_in_groups(medrecord=medrecord)
 
         if len(treated_outcome_false) == 0:
-            raise ValueError(
-                "No subjects found in the group of treated with no outcome"
-            )
+            msg = "No subjects found in the group of treated with no outcome"
+            raise ValueError(msg)
+
         if len(control_outcome_true) == 0:
-            raise ValueError("No subjects found in the group of controls with outcome")
+            msg = "No subjects found in the group of controls with outcome"
+            raise ValueError(msg)
+
         if len(control_outcome_false) == 0:
-            raise ValueError(
-                "No subjects found in the group of controls with no outcome"
-            )
+            msg = "No subjects found in the group of controls with no outcome"
+            raise ValueError(msg)
+
         return (
             len(treated_outcome_true),
             len(treated_outcome_false),
@@ -247,7 +257,11 @@ class Estimate:
         )
 
     def subject_indices(self, medrecord: MedRecord) -> SubjectIndices:
-        """Overview of which subjects are in the treatment and control groups and whether they have the outcome or not.
+        """Overview of which subjects are in which group from the contingency table.
+
+        Returns a dictionary with the patient ids of all contingency table groups, i.e.,
+        the treated group with and without the outcome, and the control group with and
+        without the outcome.
 
         Args:
             medrecord (MedRecord): The MedRecord object containing the data.
@@ -255,10 +269,6 @@ class Estimate:
         Returns:
             SubjectIndices: Dictionary with the patient ids of true and false subjects
                 in the treatment and control groups, respectively.
-
-        Raises:
-            ValueError: Raises Error if the required groups are not present in the
-                MedRecord (patients, treatments, outcomes).
         """
         (
             treated_outcome_true,
@@ -275,7 +285,10 @@ class Estimate:
         )
 
     def subject_counts(self, medrecord: MedRecord) -> ContingencyTable:
-        """Returns the subject counts for the treatment and control groups in a contingency table object.
+        """Overview of how many subjects are in which group from the contingency table.
+
+        Returns a contingency table object with the number of subjects in the treatment
+        and control groups with and without the outcome.
 
         Args:
             medrecord (MedRecord): The MedRecord object containing the data.
@@ -284,14 +297,6 @@ class Estimate:
             ContingencyTable: The contingency table object containing the number of
                 subjects in the treatment and control groups with and without the
                 outcome.
-
-        Raises:
-            ValueError: Raises error if the required groups are not present in the
-                MedRecord (patients, treatments, outcomes).
-            ValueError: If there are no subjects in the group of treated with no
-                outcome, in the one of controls with outcome or in the one of controls
-                with no outcome, an error is raised. This would result in division by
-                zero errors.
         """
         (
             number_treated_outcome_true,
@@ -308,9 +313,11 @@ class Estimate:
         )
 
     def relative_risk(self, medrecord: MedRecord) -> float:
-        """Calculates the relative risk (RR) of an event occurring in the treatment group compared to the control group.
+        """Calculates the relative risk (RR) of an event.
 
-        RR is a key measure in epidemiological studies for estimating the likelihood of an event in one group relative to another.
+        RR is a key measure in epidemiological studies for estimating the likelihood of
+        an event in one group relative to another, in this case, the treatment group
+        compared to the control group.
 
         The interpretation of RR is as follows:
         - RR = 1 indicates no difference in risk between the two groups.
@@ -323,14 +330,6 @@ class Estimate:
         Returns:
             float: The calculated relative risk between the treatment and control
                 groups.
-
-        Raises:
-            ValueError: Raises Error if the required groups are not present in the
-                MedRecord (patients, treatments, outcomes).
-            ValueError: If there are no subjects in the group of treated with no
-                outcome, in the one of controls with outcome or in the one of controls
-                with no outcome, an error is raised. This would result in division by
-                zero errors.
         """
         (
             number_treated_outcome_true,
@@ -348,11 +347,14 @@ class Estimate:
         )
 
     def odds_ratio(self, medrecord: MedRecord) -> float:
-        """Calculates the odds ratio (OR) to quantify the association between exposure to a treatment and the occurrence of an outcome.
+        """Calculates the odds ratio (OR).
 
-        OR compares the odds of an event occurring in the treatment group to the odds in the control group, providing
-        insight into the strength of the association between the treatment and the
-        outcome.
+        The OR quantifies the association between exposure to a treatment and the
+        occurrence of an outcome.
+
+        OR compares the odds of an event occurring in the treatment group to the odds
+        in the control group, providing insight into the strength of the association
+        between the treatment and the outcome.
 
         Interpretation of the odds ratio:
         - OR = 1 indicates no difference in odds between the two groups.
@@ -364,14 +366,6 @@ class Estimate:
 
         Returns:
             float: The calculated odds ratio between the treatment and control groups.
-
-        Raises:
-            ValueError: Raises Error if the required groups are not present in the
-                MedRecord (patients, treatments, outcomes).
-            ValueError: If there are no subjects in the group of treated with no
-                outcome, in the one of controls with outcome or in the one of controls
-                with no outcome, an error is raised. This would result in division by
-                zero errors.
         """
         (
             number_treated_outcome_true,
@@ -385,29 +379,27 @@ class Estimate:
         )
 
     def confounding_bias(self, medrecord: MedRecord) -> float:
-        """Calculates the confounding bias (CB) to assess the impact of potential confounders on the observed association between treatment and outcome.
+        """Calculates the confounding bias (CB).
 
-        A confounder is a variable that influences both the dependent (outcome) and independent (treatment) variables, potentially biasing the study results.
+        The CB is used to assess the impact of potential confounders on the observed
+        association between treatment and outcome. A confounder is a variable that
+        influences both the dependent (outcome) and independent (treatment) variables,
+        potentially biasing the study results.
 
         Interpretation of CB:
         - CB = 1 indicates no confounding bias.
-        - CB != 1 suggests the presence of confounding bias, indicating potential confounders.
+        - CB != 1 suggests the presence of confounding bias.
 
-        The method relies on the relative risk (RR) as an intermediary measure and adjusts the observed association for potential confounding effects. This adjustment helps in identifying whether the observed association might be influenced by factors other than the treatment.
+        The method relies on the relative risk (RR) as an intermediary measure and
+        adjusts the observed association for potential confounding effects. This
+        adjustment helps in identifying whether the observed association might be
+        influenced by factors other than the treatment.
 
         Args:
             medrecord (MedRecord): The MedRecord object containing the data.
 
         Returns:
             float: The calculated confounding bias.
-
-        Raises:
-            ValueError: If the required groups are not present in the MedRecord
-                (patients, treatments, outcomes).
-            ValueError: If there are no subjects in the group of treated with no
-                outcome, in the one of controls with outcome or in the one of controls
-                with no outcome, an error is raised. This would result in division by
-                zero errors.
         """
         (
             number_treated_outcome_true,
@@ -433,12 +425,12 @@ class Estimate:
         return numerator / denominator
 
     def absolute_risk_reduction(self, medrecord: MedRecord) -> float:
-        """Calculates the absolute risk reduction (ARR) of an event occurring in the treatment group compared to the control group.
+        """Calculates the absolute risk reduction (ARR).
 
-        AR is a measure of the incidence of an event in each group. ARR quantifies in
-        turn the difference in risk between the treatment and control groups. It is
-        positive if the treatment reduces the risk, and negative if it increases the
-        risk.
+        AR (absolute risk) is a measure of the incidence of an event in each group.
+        ARR, in turn, quantifies the difference in risk between the treatment and
+        control groups. It is positive if the treatment reduces the risk, and negative
+        if it increases the risk.
 
         Args:
             medrecord (MedRecord): The MedRecord object containing the data.
@@ -446,14 +438,6 @@ class Estimate:
         Returns:
             float: The calculated absolute risk reduction between the treatment and
                 control groups.
-
-        Raises:
-            ValueError: Raises Error if the required groups are not present in the
-                MedRecord (patients, treatments, outcomes).
-            ValueError: If there are no subjects in the group of treated with no
-                outcome, in the one of controls with outcome or in the one of controls
-                with no outcome, an error is raised. This would result in division by
-                zero errors.
         """
         (
             number_treated_outcome_true,
@@ -472,7 +456,7 @@ class Estimate:
         return ar_control_group - ar_treated_group
 
     def number_needed_to_treat(self, medrecord: MedRecord) -> float:
-        """Calculates the number needed to treat (NNT) to prevent one additional bad outcome.
+        """Calculates the number needed to treat (NNT) to prevent one extra bad outcome.
 
         NNT is derived from the absolute risk reduction (ARR) and provides an estimate
         of the number of patients that need to be treated to prevent one additional bad
@@ -496,11 +480,13 @@ class Estimate:
         """
         absolute_risk_reduction = self.absolute_risk_reduction(medrecord)
         if absolute_risk_reduction == 0:
-            raise ValueError("Absolute Risk Reduction is zero, cannot calculate NNT.")
+            msg = "Absolute Risk Reduction is zero, cannot calculate NNT."
+            raise ValueError(msg)
+
         return 1 / absolute_risk_reduction
 
     def hazard_ratio(self, medrecord: MedRecord) -> float:
-        """Calculates the hazard ratio (HR) for the treatment group compared to the control group.
+        """Calculates the hazard ratio (HR).
 
         HR is used to compare the hazard rates of two groups in survival analysis.
 
@@ -545,9 +531,14 @@ class Estimate:
         outcome_variable: MedRecordAttribute,
         reference: Literal["first", "last"] = "last",
     ) -> float:
-        """Calculates the Average Treatment Effect (ATE) as the difference between the outcome means of the treated and control sets.
+        """Calculates the Average Treatment Effect (ATE).
 
-        A positive ATE indicates that the treatment increased the outcome, while a negative ATE suggests a decrease.
+        It is calculated as the difference between the outcome means of the treated and
+        control sets. A positive ATE indicates that the treatment increased the outcome,
+        while a negative ATE suggests a decrease.
+
+        The ATE is computed as follows when the numbers of observations in treated and
+        control sets are N and M, respectively:
 
         Args:
             medrecord (MedRecord): An instance of the MedRecord class containing medical
@@ -579,18 +570,21 @@ class Estimate:
         medrecord: MedRecord,
         outcome_variable: MedRecordAttribute,
         reference: Literal["first", "last"] = "last",
-        add_correction: bool = False,
     ) -> float:
-        """Calculates Cohen's D, the standardized mean difference between two sets, measuring the effect size of the difference between two outcome means.
+        """Calculates Cohen's D, the standardized mean difference between two sets.
 
+        This measures the effect size of the difference between two outcome means.
         It's applicable for any two sets but is recommended for sets of the same size.
         Cohen's D indicates how many standard deviations the two groups differ by, with
         1 standard deviation equal to 1 z-score.
 
         A rule of thumb for interpreting Cohen's D:
-        - Small effect = 0.2
-        - Medium effect = 0.5
-        - Large effect = 0.8
+        - Small effect = ±0.2
+        - Medium effect = ±0.5
+        - Large effect = ±0.8
+
+        If the difference is negative, it indicates the mean in the treated group is
+        lower than the control group.
 
         This metric provides a dimensionless measure of effect size, facilitating the
         comparison across different studies and contexts.
@@ -620,5 +614,44 @@ class Estimate:
             outcome_variable=outcome_variable,
             reference=reference,
             time_attribute=self._treatment_effect._time_attribute,
-            add_correction=add_correction,
+        )
+
+    def hedges_g(
+        self,
+        medrecord: MedRecord,
+        outcome_variable: MedRecordAttribute,
+        reference: Literal["first", "last"] = "last",
+    ) -> float:
+        """Calculates Hedges' g, the unbiased effect size estimate.
+
+        Hedges' g is a corrected version of Cohen's d that provides an unbiased estimate
+        of the effect size, especially important when sample sizes are small (under 50).
+
+        The correction factor is applied regardless of the sample size.
+
+        Args:
+            medrecord (MedRecord): An instance of the MedRecord class containing medical
+                data.
+            outcome_variable (MedRecordAttribute): The attribute in the edge that
+                contains the outcome variable. It must be numeric and continuous.
+            reference (Literal["first", "last"], optional): The reference point for the
+                exposure time. Options include "first" and "last". If "first", the
+                function returns the earliest exposure edge. If "last", the function
+                returns the latest exposure edge. Defaults to "last".
+            add_correction (bool, optional): Whether to apply a correction factor for
+                small sample sizes. Defaults to False.
+
+        Returns:
+            float: The Hedges' g coefficient, representing the effect size.
+        """
+        subjects = self.subject_indices(medrecord=medrecord)
+
+        return hedges_g(
+            medrecord=medrecord,
+            treatment_outcome_true_set=subjects.get("treated_outcome_true"),
+            control_outcome_true_set=subjects.get("control_outcome_true"),
+            outcome_group=self._treatment_effect._outcomes_group,
+            outcome_variable=outcome_variable,
+            reference=reference,
+            time_attribute=self._treatment_effect._time_attribute,
         )

--- a/medmodels/treatment_effect/matching/algorithms/classic_distance_models.py
+++ b/medmodels/treatment_effect/matching/algorithms/classic_distance_models.py
@@ -1,9 +1,4 @@
-"""Models for matching treated and control units based on distance metrics.
-
-This module contains functions for matching treated and control units based on
-distance metrics. The functions are used to find the nearest neighbors in the
-control set for each treated patient.
-"""
+"""Models for matching treated and control units based on distance metrics."""
 
 from __future__ import annotations
 
@@ -90,7 +85,7 @@ def normalize_data(
     """Normalizes the data of the control and treated sets on the specified covariates.
 
     The values of the specified covariates on the control and treated sets are
-    normalized. Thi is performed by taking the maximum and minimum values of the
+    normalized. This is performed by taking the maximum and minimum values of the
     combined treated and control sets and subtracting the minimum values from the
     data and dividing by the difference between the maximum and minimum values. The
     normalized data is then returned in the form of numpy arrays.

--- a/medmodels/treatment_effect/matching/algorithms/propensity_score.py
+++ b/medmodels/treatment_effect/matching/algorithms/propensity_score.py
@@ -1,3 +1,12 @@
+"""Propensity Score Matching.
+
+This module provides functions for calculating propensity scores and executing
+propensity score matching. The propensity score is the probability of being in the
+treatment group given a set of covariates. Propensity score matching is a method for
+matching treated and control units based on their propensity scores, ensuring that the
+two groups are comparable.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Tuple, Union
@@ -36,7 +45,10 @@ def calculate_propensity(
     model: Model = "logit",
     hyperparam: Optional[Dict[str, Any]] = None,
 ) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
-    """Trains a classification algorithm on training data, predicts the probability of being in the last class for treated and control test datasets, and returns these probabilities.
+    """Calculates the propensity/probabilities of a subject being in the treated group.
+
+    A classification algorithm is trained, and it is used to predict the probability of
+    a subject of being either in the treated or in the control set of patients.
 
     This function supports multiple classification algorithms and allows specifying
     hyperparameters. It is designed for binary classification tasks, focusing on the

--- a/medmodels/treatment_effect/matching/covariates/metrics.py
+++ b/medmodels/treatment_effect/matching/covariates/metrics.py
@@ -9,9 +9,10 @@ from numpy.typing import NDArray
 def absolute_metric(
     vector1: NDArray[np.float64], vector2: NDArray[np.float64]
 ) -> float:
-    r"""Calculates the Manhattan distance (L1 norm) between two vectors, providing a measure of the absolute difference between them.
+    r"""Calculates the Manhattan distance (L1 norm) between two vectors.
 
-    This distance is the sum of the absolute differences between each corresponding pair of elements in the two vectors.
+    This distance is the sum of the absolute differences between each corresponding
+    pair of elements in the two vectors.
 
     The calculation is based on the formula:
 
@@ -26,17 +27,20 @@ def absolute_metric(
 
     Returns:
         float: The Manhattan distance between the two vectors.
-    """
+    """  # noqa: W505
     diff = vector1 - vector2
 
     return sum(np.abs(diff))
 
 
 def exact_metric(vector1: NDArray[np.float64], vector2: NDArray[np.float64]) -> float:
-    r"""Computes the exact metric for matching, which is particularly applicable for discrete or categorical covariates rather than continuous ones.
+    r"""Computes the exact metric between two vector.
 
-    This metric returns 0 if the two vectors are exactly identical, and infinity otherwise, making it
-    suitable for scenarios where exact matches are necessary.
+    This exact metric can be used for matching, which is particularly applicable for
+    discrete or categorical covariates rather than continuous ones.
+
+    This metric returns 0 if the two vectors are exactly identical, and infinity
+    otherwise, making it suitable for scenarios where exact matches are necessary.
 
     The exact metric is defined as:
 
@@ -54,7 +58,7 @@ def exact_metric(vector1: NDArray[np.float64], vector2: NDArray[np.float64]) -> 
         vector2 (NDArray[np.float64]): The second vector to be compared.
 
     Returns:
-        float: 0 if the vectors are equal, infinity if they are not.
+        float: 0 if the vectors are equal, infinity otherwise.
 
     Note:
         This function is designed for exactly two input vectors.

--- a/medmodels/treatment_effect/matching/covariates/metrics.py
+++ b/medmodels/treatment_effect/matching/covariates/metrics.py
@@ -34,7 +34,7 @@ def absolute_metric(
 
 
 def exact_metric(vector1: NDArray[np.float64], vector2: NDArray[np.float64]) -> float:
-    r"""Computes the exact metric between two vector.
+    r"""Computes the exact metric between two vectors.
 
     This exact metric can be used for matching, which is particularly applicable for
     discrete or categorical covariates rather than continuous ones.

--- a/medmodels/treatment_effect/matching/matching.py
+++ b/medmodels/treatment_effect/matching/matching.py
@@ -1,4 +1,4 @@
-"""Matching abstract class.
+"""Module containing the matching abstract class.
 
 Matching is the process of selecting control subjects that are similar to treated
 subjects. The class provides the base for the matching algorithms, such as propensity
@@ -27,7 +27,7 @@ MatchingMethod: TypeAlias = Literal["propensity", "nearest_neighbors"]
 
 
 class Matching(ABC):
-    """The Base Class for matching."""
+    """The Abstract Class for matching."""
 
     def _preprocess_data(
         self,

--- a/medmodels/treatment_effect/matching/matching.py
+++ b/medmodels/treatment_effect/matching/matching.py
@@ -1,7 +1,14 @@
+"""Matching abstract class.
+
+Matching is the process of selecting control subjects that are similar to treated
+subjects. The class provides the base for the matching algorithms, such as propensity
+score matching and nearest neighbor matching.
+"""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Literal, Set, Tuple
+from typing import TYPE_CHECKING, Literal, Optional, Set, Tuple
 
 import polars as pl
 
@@ -86,6 +93,21 @@ class Matching(ABC):
         control_group: Set[NodeIndex],
         treated_group: Set[NodeIndex],
         medrecord: MedRecord,
-        essential_covariates: MedRecordAttributeInputList = ["gender", "age"],
-        one_hot_covariates: MedRecordAttributeInputList = ["gender"],
-    ) -> Set[NodeIndex]: ...
+        essential_covariates: Optional[MedRecordAttributeInputList] = None,
+        one_hot_covariates: Optional[MedRecordAttributeInputList] = None,
+    ) -> Set[NodeIndex]:
+        """Matches the controls based on the matching algorithm.
+
+        Args:
+            medrecord (MedRecord): MedRecord object containing the data.
+            treated_group (Set[NodeIndex]): Set of treated subjects.
+            control_group (Set[NodeIndex]): Set of control subjects.
+            essential_covariates (Optional[MedRecordAttributeInputList], optional):
+                Covariates that are essential for matching. Defaults to None.
+            one_hot_covariates (Optional[MedRecordAttributeInputList], optional):
+                Covariates that are one-hot encoded for matching. Defaults to None.
+
+        Returns:
+            Set[NodeIndex]: Node Ids of the matched controls.
+        """
+        ...

--- a/medmodels/treatment_effect/matching/neighbors.py
+++ b/medmodels/treatment_effect/matching/neighbors.py
@@ -1,6 +1,8 @@
+"""Module for the nearest neighbor matching."""
+
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Set
+from typing import TYPE_CHECKING, Optional, Set
 
 from medmodels.treatment_effect.matching.algorithms.classic_distance_models import (
     nearest_neighbor,
@@ -42,8 +44,8 @@ class NeighborsMatching(Matching):
         medrecord: MedRecord,
         control_group: Set[NodeIndex],
         treated_group: Set[NodeIndex],
-        essential_covariates: MedRecordAttributeInputList = None,
-        one_hot_covariates: MedRecordAttributeInputList = None,
+        essential_covariates: Optional[MedRecordAttributeInputList] = None,
+        one_hot_covariates: Optional[MedRecordAttributeInputList] = None,
     ) -> Set[NodeIndex]:
         """Matches the controls based on the nearest neighbor algorithm.
 
@@ -51,18 +53,21 @@ class NeighborsMatching(Matching):
             medrecord (MedRecord): MedRecord object containing the data.
             treated_group (Set[NodeIndex]): Set of treated subjects.
             control_group (Set[NodeIndex]): Set of control subjects.
-            essential_covariates (MedRecordAttributeInputList, optional): Covariates
-                that are essential for matching
-            one_hot_covariates (MedRecordAttributeInputList, optional): Covariates that
-                are one-hot encoded for matching
+            essential_covariates (Optional[MedRecordAttributeInputList], optional):
+                Covariates that are essential for matching. Defaults to
+                ["gender", "age"].
+            one_hot_covariates (Optional[MedRecordAttributeInputList], optional):
+                Covariates that are one-hot encoded for matching. Defaults to
+                ["gender"].
 
         Returns:
             Set[NodeIndex]: Node Ids of the matched controls.
         """
-        if one_hot_covariates is None:
-            one_hot_covariates = ["gender"]
         if essential_covariates is None:
             essential_covariates = ["gender", "age"]
+        if one_hot_covariates is None:
+            one_hot_covariates = ["gender"]
+
         data_treated, data_control = self._preprocess_data(
             medrecord=medrecord,
             control_group=control_group,

--- a/medmodels/treatment_effect/matching/propensity.py
+++ b/medmodels/treatment_effect/matching/propensity.py
@@ -1,3 +1,5 @@
+"""Module for the propensity score matching."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, Optional, Set
@@ -62,8 +64,8 @@ class PropensityMatching(Matching):
         medrecord: MedRecord,
         control_group: Set[NodeIndex],
         treated_group: Set[NodeIndex],
-        essential_covariates: MedRecordAttributeInputList = None,
-        one_hot_covariates: MedRecordAttributeInputList = None,
+        essential_covariates: Optional[MedRecordAttributeInputList] = None,
+        one_hot_covariates: Optional[MedRecordAttributeInputList] = None,
     ) -> Set[NodeIndex]:
         """Matches the controls based on propensity score matching.
 
@@ -71,19 +73,22 @@ class PropensityMatching(Matching):
             medrecord (MedRecord): medrecord object containing the data.
             treated_group (Set[NodeIndex]): Set of treated subjects.
             control_group (Set[NodeIndex]): Set of control subjects.
-            essential_covariates (MedRecordAttributeInputList, optional): Covariates
-                that are essential for matching. Defaults to ["gender", "age"].
-            one_hot_covariates (MedRecordAttributeInputList, optional): Covariates that
-                are one-hot encoded for matching. Defaults to ["gender"].
+            essential_covariates (Optional[MedRecordAttributeInputList], optional):
+                Covariates that are essential for matching. Defaults to
+                ["gender", "age"].
+            one_hot_covariates (Optional[MedRecordAttributeInputList], optional):
+                Covariates that are one-hot encoded for matching. Defaults to
+                ["gender"].
 
         Returns:
             Set[NodeIndex]:  Node Ids of the matched controls.
         """
-        # Preprocess the data
-        if one_hot_covariates is None:
-            one_hot_covariates = ["gender"]
         if essential_covariates is None:
             essential_covariates = ["gender", "age"]
+        if one_hot_covariates is None:
+            one_hot_covariates = ["gender"]
+
+        # Preprocess the data
         data_treated, data_control = self._preprocess_data(
             medrecord=medrecord,
             treated_group=treated_group,
@@ -91,6 +96,7 @@ class PropensityMatching(Matching):
             essential_covariates=essential_covariates,
             one_hot_covariates=one_hot_covariates,
         )
+
         # Convert the Polars DataFrames to NumPy arrays
         treated_array = data_treated.drop("id").cast(pl.Float64, strict=True).to_numpy()
         control_array = data_control.drop("id").cast(pl.Float64, strict=True).to_numpy()
@@ -104,7 +110,8 @@ class PropensityMatching(Matching):
             )
         )
 
-        treated_prop, control_prop = calculate_propensity(
+        # Calculate the propensity scores for the treated and control sets
+        treated_propensity, control_propensity = calculate_propensity(
             x_train=x_train,
             y_train=y_train,
             treated_test=treated_array,
@@ -114,8 +121,12 @@ class PropensityMatching(Matching):
         )
 
         # Add propensity score to the original data polars dataframes
-        data_treated = data_treated.with_columns(pl.Series("prop_score", treated_prop))
-        data_control = data_control.with_columns(pl.Series("prop_score", control_prop))
+        data_treated = data_treated.with_columns(
+            pl.Series("prop_score", treated_propensity)
+        )
+        data_control = data_control.with_columns(
+            pl.Series("prop_score", control_propensity)
+        )
 
         matched_control = nearest_neighbor(
             data_treated,

--- a/medmodels/treatment_effect/matching/tests/test_metrics.py
+++ b/medmodels/treatment_effect/matching/tests/test_metrics.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+import pytest
 
 from medmodels.treatment_effect.matching.covariates import metrics
 
@@ -27,13 +28,13 @@ class TestMetrics(unittest.TestCase):
         inv_cov = np.linalg.inv(np.cov(data))
         a1, a2 = np.array([68, 600, 40]), np.array([66, 640, 44])
         result = metrics.mahalanobis_metric(a1, a2, inv_cov=inv_cov)
-        self.assertAlmostEqual(result, 5.33, 2)
+        assert result == pytest.approx(5.33, 2)
 
         data = np.array([[-2.1, -1, 4.3]])
         inv_cov = 1 / np.cov(data)
         a1, a2 = np.array([1]), np.array([2])
         result = metrics.mahalanobis_metric(a1, a2, inv_cov=inv_cov)
-        self.assertAlmostEqual(result, 0.29, 2)
+        assert result == pytest.approx(0.29, 2)
 
 
 if __name__ == "__main__":

--- a/medmodels/treatment_effect/matching/tests/test_propensity_score.py
+++ b/medmodels/treatment_effect/matching/tests/test_propensity_score.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy as np
 import polars as pl
+import pytest
 from sklearn.datasets import load_iris
 
 from medmodels.treatment_effect.matching.algorithms import propensity_score as ps
@@ -21,8 +22,8 @@ class TestPropensityScore(unittest.TestCase):
         result_1, result_2 = ps.calculate_propensity(
             x, y, np.array([x[0, :]]), np.array([x[1, :]]), hyperparam=hyperparam_logit
         )
-        self.assertAlmostEqual(result_1[0], 1.43580537e-08, places=9)
-        self.assertAlmostEqual(result_2[0], 3.00353141e-08, places=9)
+        assert result_1[0] == pytest.approx(1.4e-08, 9)
+        assert result_2[0] == pytest.approx(3e-08, 9)
 
         # Decision Tree Classifier model:
         result_1, result_2 = ps.calculate_propensity(
@@ -33,8 +34,8 @@ class TestPropensityScore(unittest.TestCase):
             model="dec_tree",
             hyperparam=hyperparam,
         )
-        self.assertAlmostEqual(result_1[0], 0, places=2)
-        self.assertAlmostEqual(result_2[0], 0, places=2)
+        assert result_1[0] == pytest.approx(0, 2)
+        assert result_2[0] == pytest.approx(0, 2)
 
         # Random Forest Classifier model:
         result_1, result_2 = ps.calculate_propensity(
@@ -45,8 +46,8 @@ class TestPropensityScore(unittest.TestCase):
             model="forest",
             hyperparam=hyperparam,
         )
-        self.assertAlmostEqual(result_1[0], 0, places=2)
-        self.assertAlmostEqual(result_2[0], 0, places=2)
+        assert result_1[0] == pytest.approx(0, 2)
+        assert result_2[0] == pytest.approx(0, 2)
 
     def test_run_propensity_score(self) -> None:
         # Set random state by each propensity estimator:

--- a/medmodels/treatment_effect/report.py
+++ b/medmodels/treatment_effect/report.py
@@ -1,3 +1,5 @@
+"""This module contains functions t generate reports of the treatment effect class."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, TypedDict
@@ -9,6 +11,8 @@ if TYPE_CHECKING:
 
 
 class FullReport(TypedDict):
+    """A dictionary containing the results of all estimation methods."""
+
     relative_risk: float
     odds_ratio: float
     confounding_bias: float
@@ -18,14 +22,25 @@ class FullReport(TypedDict):
 
 
 class ContinuousReport(TypedDict):
+    """A dictionary containing the results of continuous treatment effect estimators."""
+
     average_treatment_effect: float
     cohens_d: float
+    hedges_g: float
 
 
 class Report:
+    """Class to generate reports of the treatment effect class."""
+
     _treatment_effect: TreatmentEffect
 
     def __init__(self, treatment_effect: TreatmentEffect) -> None:
+        """Initializes the Report class.
+
+        Args:
+            treatment_effect (TreatmentEffect): An instance of the TreatmentEffect
+                class.
+        """
         self._treatment_effect = treatment_effect
 
     def full_report(self, medrecord: MedRecord) -> FullReport:
@@ -60,7 +75,6 @@ class Report:
         medrecord: MedRecord,
         outcome_variable: MedRecordAttribute,
         reference: Literal["first", "last"] = "last",
-        add_cohens_d_correction: bool = False,
     ) -> ContinuousReport:
         """Generates a report of continuous treatment effect estimators.
 
@@ -73,12 +87,11 @@ class Report:
                 exposure time. Options include "first" and "last". If "first", the
                 function returns the earliest exposure edge. If "last", the function
                 returns the latest exposure edge. Defaults to "last".
-            add_cohens_d_correction (bool, optional): A boolean indicating whether to
-                include a correction for Cohen's d. Defaults to False.
 
         Returns:
             ContinuousReport: A dictionary containing the results of continuous
-                treatment effect estimators: average treatment effect and Cohen's d.
+                treatment effect estimators: average treatment effect, Cohen's d and
+                Hedges' g.
         """
         average_treatment_effect = (
             self._treatment_effect.estimate.average_treatment_effect(
@@ -91,9 +104,15 @@ class Report:
             medrecord,
             outcome_variable,
             reference=reference,
-            add_correction=add_cohens_d_correction,
         )
+        hedges_g_value = self._treatment_effect.estimate.hedges_g(
+            medrecord,
+            outcome_variable,
+            reference=reference,
+        )
+
         return {
             "average_treatment_effect": average_treatment_effect,
             "cohens_d": cohens_d_value,
+            "hedges_g": hedges_g_value,
         }

--- a/medmodels/treatment_effect/report.py
+++ b/medmodels/treatment_effect/report.py
@@ -1,4 +1,4 @@
-"""This module contains functions t generate reports of the treatment effect class."""
+"""This module contains functions to generate reports of the treatment effect class."""
 
 from __future__ import annotations
 

--- a/medmodels/treatment_effect/tests/test_temporal_analysis.py
+++ b/medmodels/treatment_effect/tests/test_temporal_analysis.py
@@ -1,15 +1,19 @@
+from __future__ import annotations
+
 import unittest
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 import pandas as pd
 import pytest
 
 from medmodels.medrecord.medrecord import MedRecord
-from medmodels.medrecord.types import NodeIndex
 from medmodels.treatment_effect.temporal_analysis import (
     find_node_in_time_window,
     find_reference_edge,
 )
+
+if TYPE_CHECKING:
+    from medmodels.medrecord.types import NodeIndex
 
 
 def create_patients(patient_list: List[NodeIndex]) -> pd.DataFrame:

--- a/medmodels/treatment_effect/treatment_effect.py
+++ b/medmodels/treatment_effect/treatment_effect.py
@@ -37,6 +37,8 @@ if TYPE_CHECKING:
     from medmodels.treatment_effect.matching.algorithms.propensity_score import Model
     from medmodels.treatment_effect.matching.matching import MatchingMethod
 
+logger = logging.getLogger(__name__)
+
 
 class TreatmentEffect:
     """The TreatmentEffect class for analyzing treatment effects in medical records."""
@@ -72,7 +74,7 @@ class TreatmentEffect:
         treatment: Group,
         outcome: Group,
     ) -> None:
-        """Initializes a Treatment Effect analysis setup.
+        """Instantiates a Treatment Effect class.
 
         It requires the group of the Medrecord that contains the treatment node IDs and
         the group of the Medrecord that contains the outcome node IDs.
@@ -116,7 +118,7 @@ class TreatmentEffect:
         matching_number_of_neighbors: int = 1,
         matching_hyperparameters: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Initializes a Treatment Effect analysis setup.
+        """Sets the configuration for the TreatmentEffect instance.
 
         Validates the presence of specified dimensions and attributes within the
         provided MedRecord object, ensuring the specified treatments and outcomes are
@@ -354,7 +356,7 @@ class TreatmentEffect:
         treated_group -= outcome_before_treatment_nodes
         if outcome_before_treatment_nodes:
             dropped_num = len(outcome_before_treatment_nodes)
-            logging.warning(
+            logger.warning(
                 "%d subject%s dropped due to outcome before treatment.",
                 dropped_num,
                 " was" if dropped_num == 1 else "s were",
@@ -406,7 +408,7 @@ class TreatmentEffect:
 
         if washout_nodes:
             dropped_num = len(washout_nodes)
-            logging.warning(
+            logger.warning(
                 "%d subject%s dropped due to outcome before treatment.",
                 dropped_num,
                 " was" if dropped_num == 1 else "s were",

--- a/medmodels/treatment_effect/treatment_effect.py
+++ b/medmodels/treatment_effect/treatment_effect.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 
 
 class TreatmentEffect:
-    """This class facilitates the analysis of treatment effects over time and across different patient groups."""
+    """The TreatmentEffect class for analyzing treatment effects in medical records."""
 
     _treatments_group: Group
     _outcomes_group: Group
@@ -65,14 +65,17 @@ class TreatmentEffect:
     _matching_one_hot_covariates: MedRecordAttributeInputList
     _matching_model: Model
     _matching_number_of_neighbors: int
-    _matching_hyperparam: Optional[Dict[str, Any]]
+    _matching_hyperparameters: Optional[Dict[str, Any]]
 
     def __init__(
         self,
         treatment: Group,
         outcome: Group,
     ) -> None:
-        """Initializes a Treatment Effect analysis setup with the group of the Medrecord that contains the treatment node IDs and the group of the Medrecord that contains the outcome node IDs.
+        """Initializes a Treatment Effect analysis setup.
+
+        It requires the group of the Medrecord that contains the treatment node IDs and
+        the group of the Medrecord that contains the outcome node IDs.
 
         Args:
             treatment (Group): The group of treatments to analyze.
@@ -82,7 +85,12 @@ class TreatmentEffect:
 
     @classmethod
     def builder(cls) -> TreatmentEffectBuilder:
-        """Creates a TreatmentEffectBuilder instance for the TreatmentEffect class."""
+        """Creates a TreatmentEffectBuilder instance for the TreatmentEffect class.
+
+        Returns:
+            TreatmentEffectBuilder: A TreatmentEffectBuilder instance for the
+                TreatmentEffect class.
+        """
         return TreatmentEffectBuilder()
 
     @staticmethod
@@ -102,19 +110,21 @@ class TreatmentEffect:
         outcome_before_treatment_days: Optional[int] = None,
         filter_controls_query: Optional[NodeQuery] = None,
         matching_method: Optional[MatchingMethod] = None,
-        matching_essential_covariates: MedRecordAttributeInputList = None,
-        matching_one_hot_covariates: MedRecordAttributeInputList = None,
+        matching_essential_covariates: Optional[MedRecordAttributeInputList] = None,
+        matching_one_hot_covariates: Optional[MedRecordAttributeInputList] = None,
         matching_model: Model = "logit",
         matching_number_of_neighbors: int = 1,
-        matching_hyperparam: Optional[Dict[str, Any]] = None,
+        matching_hyperparameters: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Initializes a Treatment Effect analysis setup with specified treatments and outcomes within a medical record dataset.
+        """Initializes a Treatment Effect analysis setup.
 
         Validates the presence of specified dimensions and attributes within the
         provided MedRecord object, ensuring the specified treatments and outcomes are
         valid and available for analysis.
 
         Args:
+            treatment_effect (TreatmentEffect): The TreatmentEffect instance to
+                configure.
             treatment (Group): The group of treatments to analyze.
             outcome (Group): The group of outcomes to analyze.
             patients_group (Group, optional): The group of patients to analyze.
@@ -140,25 +150,26 @@ class TreatmentEffect:
                 Defaults to None.
             matching_method (Optional[MatchingMethod]): The method to match treatment
                 and control groups. Defaults to None.
-            matching_essential_covariates (MedRecordAttributeInputList, optional):
+            matching_essential_covariates (Optional[MedRecordAttributeInputList], optional):
                 The essential covariates to use for matching. Defaults to
                 ["gender", "age"].
-            matching_one_hot_covariates (MedRecordAttributeInputList, optional):
+            matching_one_hot_covariates (Optional[MedRecordAttributeInputList], optional):
                 The one-hot covariates to use for matching. Defaults to
                 ["gender"].
             matching_model (Model, optional): The model to use for matching.
                 Defaults to "logit".
             matching_number_of_neighbors (int, optional): The number of
                 neighbors to match for each treated subject. Defaults to 1.
-            matching_hyperparam (Optional[Dict[str, Any]], optional): The
+            matching_hyperparameters (Optional[Dict[str, Any]], optional): The
                 hyperparameters for the matching model. Defaults to None.
-        """
-        if matching_one_hot_covariates is None:
-            matching_one_hot_covariates = ["gender"]
+        """  # noqa: W505
         if washout_period_days is None:
             washout_period_days = {}
         if matching_essential_covariates is None:
             matching_essential_covariates = ["gender", "age"]
+        if matching_one_hot_covariates is None:
+            matching_one_hot_covariates = ["gender"]
+
         treatment_effect._patients_group = patients_group
         treatment_effect._time_attribute = time_attribute
 
@@ -179,16 +190,17 @@ class TreatmentEffect:
         treatment_effect._matching_one_hot_covariates = matching_one_hot_covariates
         treatment_effect._matching_model = matching_model
         treatment_effect._matching_number_of_neighbors = matching_number_of_neighbors
-        treatment_effect._matching_hyperparam = matching_hyperparam
+        treatment_effect._matching_hyperparameters = matching_hyperparameters
 
     def _find_groups(
         self, medrecord: MedRecord
     ) -> Tuple[Set[NodeIndex], Set[NodeIndex], Set[NodeIndex], Set[NodeIndex]]:
-        """Identifies patients who underwent treatment and experienced outcomes, and finds a control group with similar criteria but without undergoing the treatment.
+        """Finds the treated and control groups in the MedRecord.
 
-        This method supports customizable criteria filtering, time constraints between
-        treatment and outcome, and optional matching of control groups to treatment
-        groups using a specified matching class.
+        This method finds the patients in the treated group and the control groups and
+        whether they had the outcome or not. It supports customizable criteria
+        filtering, time constraints between treatment and outcome, and optional
+        matching of control groups to treatment groups using a specified matching class.
 
         Args:
             medrecord (MedRecord): An instance of the MedRecord class containing patient
@@ -199,9 +211,9 @@ class TreatmentEffect:
                 tuple containing the IDs of patients in the treated group who had the
                 outcome (treated_outcome_true), the IDs of patients in the treated group
                 who did not have the outcome (treatment_outcome_false), the IDs of
-                patients in the control group who had the outcome (control_outcome_true),
-                and the IDs of patients in the control group who did not have the outcome
-                (control_outcome_false).
+                patients in the control group who had the outcome
+                (control_outcome_true), and the IDs of patients in the control group
+                who did not have the outcome (control_outcome_false).
         """
         # Find patients that underwent the treatment
         treated_group = self._find_treated_patients(medrecord)
@@ -244,20 +256,16 @@ class TreatmentEffect:
             ValueError: If no patients are found for the treatment groups in the
                 MedRecord.
         """
-        treated_group = set()
 
-        treatments = medrecord.nodes_in_group(self._treatments_group)
-
-        def query(node: NodeOperand):
+        def query(node: NodeOperand) -> None:
             node.in_group(self._patients_group)
-
-            node.neighbors(edge_direction=EdgeDirection.BOTH).index().equal_to(
-                treatment
+            node.neighbors(edge_direction=EdgeDirection.BOTH).in_group(
+                self._treatments_group
             )
 
         # Create the group with all the patients that underwent the treatment
-        for treatment in treatments:
-            treated_group.update(set(medrecord.select_nodes(query)))
+        treated_group = set(medrecord.select_nodes(query))
+
         if not treated_group:
             msg = "No patients found for the treatment groups in this MedRecord."
             raise ValueError(msg)
@@ -298,7 +306,7 @@ class TreatmentEffect:
             msg = f"No outcomes found in the MedRecord for group {self._outcomes_group}"
             raise ValueError(msg)
 
-        def query(node: NodeOperand):
+        def query(node: NodeOperand) -> None:
             node.index().is_in(list(treated_group))
 
             # This could probably be refactored to a proper query
@@ -347,8 +355,9 @@ class TreatmentEffect:
         if outcome_before_treatment_nodes:
             dropped_num = len(outcome_before_treatment_nodes)
             logging.warning(
-                f"{dropped_num} subject{' was' if dropped_num == 1 else 's were'} "
-                f"dropped due to outcome before treatment."
+                "%d subject%s dropped due to outcome before treatment.",
+                dropped_num,
+                " was" if dropped_num == 1 else "s were",
             )
 
         return treated_group, treatment_outcome_true, outcome_before_treatment_nodes
@@ -374,7 +383,7 @@ class TreatmentEffect:
             return treated_group, washout_nodes
 
         # Apply the washout period to the treatment group
-        # TODO: washout in both directions? We need a List then
+        # TODO: washout in both directions? We need a List then  # noqa: TD003, TD002
         for washout_group_id, washout_days in self._washout_period_days.items():
             for washout_node in medrecord.nodes_in_group(washout_group_id):
                 washout_nodes.update(
@@ -398,8 +407,9 @@ class TreatmentEffect:
         if washout_nodes:
             dropped_num = len(washout_nodes)
             logging.warning(
-                f"{dropped_num} subject{' was' if dropped_num == 1 else 's were'} "
-                f"dropped due to outcome before treatment."
+                "%d subject%s dropped due to outcome before treatment.",
+                dropped_num,
+                " was" if dropped_num == 1 else "s were",
             )
         return treated_group, washout_nodes
 
@@ -411,7 +421,7 @@ class TreatmentEffect:
         rejected_nodes: Optional[Set[NodeIndex]] = None,
         filter_controls_query: Optional[NodeQuery] = None,
     ) -> Tuple[Set[NodeIndex], Set[NodeIndex]]:
-        """Identifies control groups among patients who did not undergo the specified treatments.
+        """Identifies control patients based on specified criteria.
 
         It takes the control group and removes the rejected nodes, the treated nodes,
         and applies the filter_controls_query if specified.
@@ -458,22 +468,19 @@ class TreatmentEffect:
             msg = "No patients found for control groups in this MedRecord."
             raise ValueError(msg)
 
-        control_outcome_true = set()
-        control_outcome_false = set()
         outcomes = medrecord.nodes_in_group(self._outcomes_group)
         if not outcomes:
             msg = f"No outcomes found in the MedRecord for group {self._outcomes_group}"
             raise ValueError(msg)
 
-        def query(node: NodeOperand):
+        def query(node: NodeOperand) -> None:
             node.index().is_in(list(control_group))
-
-            node.neighbors(edge_direction=EdgeDirection.BOTH).index().equal_to(outcome)
+            node.neighbors(edge_direction=EdgeDirection.BOTH).in_group(
+                self._outcomes_group
+            )
 
         # Finding the patients that had the outcome in the control group
-        for outcome in outcomes:
-            control_outcome_true.update(medrecord.select_nodes(query))
-
+        control_outcome_true = set(medrecord.select_nodes(query))
         control_outcome_false = control_group - control_outcome_true
 
         return control_outcome_true, control_outcome_false


### PR DESCRIPTION
Fixing linting and dosctrings in all treatment effect files. Some rework was done in `continuous.estimators.py` to add hedges_g since the add_correction boolean argument was against linting conventions.