### PR TITLE
feat: added group input variable and fixed table

### DIFF
--- a/medmodels/medrecord/_overview.py
+++ b/medmodels/medrecord/_overview.py
@@ -216,7 +216,7 @@ def prettify_table(
                     if isinstance(info[key], float):
                         row[3] = f"{key}: {info[key]:.{decimal}f}"
                     elif isinstance(info[key], datetime):
-                        row[3] = info[key].strftime("%Y-%m-%d %H:%M:%S")
+                        row[3] = f"{key}: {info[key].strftime('%Y-%m-%d %H:%M:%S')}"
                     else:
                         row[3] = f"{key}: {info[key]}"
 

--- a/medmodels/medrecord/_overview.py
+++ b/medmodels/medrecord/_overview.py
@@ -144,13 +144,13 @@ def _extract_string_attribute_info(
     Args:
         attribute_series (pl.Series): Series containing attribute values.
         short_string_prefix (Literal["Values", "Categories"], optional): Prefix for
-            Info string in case of listing all the values. Defaults to "Values".
-        long_string_suffix (str, optional): Suffix for attribute info in case of too
+            information string in case of listing all the values. Defaults to "Values".
+        long_string_suffix (str, optional): Suffix for attribute information in case of too
             many values to list. Here only the count will be displayed.
             Defaults to "unique values".
         max_number_values (int, optional): Maximum values that should be listed in the
-            info string. Defaults to 5.
-        max_line_length (int, optional): Maximum line length for the info string.
+            information string. Defaults to 5.
+        max_line_length (int, optional): Maximum line length for the information string.
             Defaults to 100.
 
     Returns:
@@ -164,7 +164,7 @@ def _extract_string_attribute_info(
         values_string = f"{len(values)} {long_string_suffix}"
 
     return {
-        "type": "Categorical" if short_string_prefix == "Categories" else "Text",
+        "type": "Categorical",
         "values": values_string,
     }
 
@@ -175,7 +175,7 @@ def prettify_table(
     """Takes a DataFrame and turns it into a list for displaying a pretty table.
 
     Args:
-        data (Dict[Group, AttributeInfo]): Table info
+        data (Dict[Group, AttributeInfo]): Table information
             stored in a dictionary.
         header (List[str]): Header line consisting of column names for the table.
         decimal (int): Decimal point to round the float values to.
@@ -219,7 +219,7 @@ def prettify_table(
 
                 row[3] = info["type"] if first_line else ""
 
-                # displaying info based on the type
+                # displaying information based on the type
                 if "values" in info.keys():
                     row[4] = info[key]
                 else:

--- a/medmodels/medrecord/medrecord.py
+++ b/medmodels/medrecord/medrecord.py
@@ -102,7 +102,7 @@ class OverviewTable:
 
     def __repr__(self) -> str:
         """Returns a string representation of the group nodes/ edges overview."""
-        header = [self.group_header, "count", "attribute", "type", "info"]
+        header = [self.group_header, "count", "attribute", "type", "data"]
 
         return "\n".join(prettify_table(self.data, header=header, decimal=self.decimal))
 
@@ -1312,14 +1312,16 @@ class MedRecord:
                 "attribute": extract_attribute_summary(self.node[nodes], schema=schema),
             }
 
-        if add_ungrouped:
-            ungrouped_count = self.node_count() - len(set(grouped_nodes))
+        if not add_ungrouped:
+            return nodes_info
 
-            if ungrouped_count > 0:
-                nodes_info["Ungrouped Nodes"] = {
-                    "count": ungrouped_count,
-                    "attribute": {},
-                }
+        ungrouped_count = self.node_count() - len(set(grouped_nodes))
+
+        if ungrouped_count > 0:
+            nodes_info["Ungrouped Nodes"] = {
+                "count": ungrouped_count,
+                "attribute": {},
+            }
 
         return nodes_info
 
@@ -1361,14 +1363,16 @@ class MedRecord:
                 "attribute": extract_attribute_summary(self.edge[edges], schema=schema),
             }
 
-        if add_ungrouped:
-            ungrouped_count = self.edge_count() - len(set(grouped_edges))
+        if not add_ungrouped:
+            return edges_info
 
-            if ungrouped_count > 0:
-                edges_info["Ungrouped Edges"] = {
-                    "count": ungrouped_count,
-                    "attribute": {},
-                }
+        ungrouped_count = self.edge_count() - len(set(grouped_edges))
+
+        if ungrouped_count > 0:
+            edges_info["Ungrouped Edges"] = {
+                "count": ungrouped_count,
+                "attribute": {},
+            }
 
         return edges_info
 
@@ -1396,16 +1400,16 @@ class MedRecord:
 
         Example:
 
-        ----------------------------------------------------
-        Nodes Group     Count Attribute   Info
-        ----------------------------------------------------
-        diagnosis       25    description 25 unique values
-        patient         5     age         min: 19
-                                          max: 96
-                                          mean: 43.20
-                              gender      Categories: F, M
-        Ungrouped Nodes 10    -           -
-        ----------------------------------------------------
+        --------------------------------------------------------------
+        Nodes Group     Count Attribute   Type        Data
+        --------------------------------------------------------------
+        diagnosis       25    description Categorical 25 unique values
+        patient         5     age         Continuous  min: 19
+                                                      max: 96
+                                                      mean: 43.20
+                              gender      Categorical Categories: F, M
+        Ungrouped Nodes 10    -           -           -
+        --------------------------------------------------------------
 
         """
         if groups:
@@ -1436,15 +1440,15 @@ class MedRecord:
 
         Example:
 
-        ----------------------------------------------------------------------------
-        Edges Group                 Count Attribute        Info
-        ----------------------------------------------------------------------------
-        Patient-Diagnosis           60    diagnosis_time   min: 1962-10-21 00:00:00
-                                                           max: 2024-04-12 00:00:00
-                                          duration_days    min: 0
-                                                           max: 3416
-                                                           mean: 405.02
-        ----------------------------------------------------------------------------
+        --------------------------------------------------------------------------
+        Edges Group       Count Attribute      Type       Data
+        --------------------------------------------------------------------------
+        Patient-Diagnosis 60    diagnosis_time Temporal   min: 1962-10-21 00:00:00
+                                                          max: 2024-04-12 00:00:00
+                                duration_days  Continuous min: 0
+                                                          max: 3416
+                                                          mean: 405.02
+        --------------------------------------------------------------------------
         """
         if groups:
             edges_data = self._describe_group_edges(

--- a/medmodels/medrecord/medrecord.py
+++ b/medmodels/medrecord/medrecord.py
@@ -101,7 +101,7 @@ class OverviewTable:
 
     def __repr__(self) -> str:
         """Returns a string representation of the group nodes/ edges overview."""
-        header = [self.group_header, "count", "attribute", "info"]
+        header = [self.group_header, "count", "attribute", "type", "info"]
 
         return "\n".join(prettify_table(self.data, header=header, decimal=self.decimal))
 
@@ -1375,14 +1375,14 @@ class MedRecord:
         return "\n".join([str(self.overview_nodes()), "", str(self.overview_edges())])
 
     def overview_nodes(
-        self, groups: Optional[GroupInputList] = None, decimal: int = 2
+        self, groups: Optional[Union[Group, GroupInputList]] = None, decimal: int = 2
     ) -> OverviewTable:
         """Gets a summary for all nodes in groups and their attributes.
 
         Args:
-            groups (Optional[GroupInputList], optional): List of node groups to display.
-                If no groups are given, all groups containing nodes are shown.
-                Defaults to None.
+            groups (Optional[Union[Group, GroupInputList]], optional): Group or list of
+                node groups to display. If no groups are given, all groups containing
+                nodes are shown. Defaults to None.
             decimal (int, optional): Decimal point to round the float values to.
                 Defaults to 2.
 
@@ -1404,21 +1404,26 @@ class MedRecord:
         ----------------------------------------------------
 
         """
-        nodes_data = self._describe_group_nodes(groups=groups)
+        if groups:
+            nodes_data = self._describe_group_nodes(
+                groups if isinstance(groups, list) else [groups]
+            )
+        else:
+            nodes_data = self._describe_group_nodes()
 
         return OverviewTable(
             data=nodes_data, group_header="Nodes Group", decimal=decimal
         )
 
     def overview_edges(
-        self, groups: Optional[GroupInputList] = None, decimal: int = 2
+        self, groups: Optional[Union[Group, GroupInputList]] = None, decimal: int = 2
     ) -> OverviewTable:
         """Gets a summary for all edges in groups and their attributes.
 
         Args:
-            groups (Optional[GroupInputList], optional): List of edge groups to display.
-                If no groups are given, all groups containing nodes are shown.
-                Defaults to None.
+            groups (Optional[Union[Group, GroupInputList]], optional): Group or list of
+                edge groups to display. If no groups are given, all groups containing
+                nodes are shown. Defaults to None.
             decimal (int, optional): Decimal point to round the float values to.
                 Defaults to 2.
 
@@ -1438,7 +1443,12 @@ class MedRecord:
                                                            mean: 405.02
         ----------------------------------------------------------------------------
         """
-        edges_data = self._describe_group_edges(groups=groups)
+        if groups:
+            edges_data = self._describe_group_edges(
+                groups if isinstance(groups, list) else [groups]
+            )
+        else:
+            edges_data = self._describe_group_edges()
 
         return OverviewTable(
             data=edges_data, group_header="Edges Group", decimal=decimal

--- a/medmodels/medrecord/medrecord.py
+++ b/medmodels/medrecord/medrecord.py
@@ -1386,7 +1386,6 @@ class MedRecord:
             decimal (int, optional): Decimal point to round the float values to.
                 Defaults to 2.
 
-
         Returns:
             OverviewTable: Display of edge groups and their attributes.
 
@@ -1429,7 +1428,6 @@ class MedRecord:
 
         Returns:
             OverviewTable: Display of edge groups and their attributes.
-
 
         Example:
 

--- a/medmodels/medrecord/tests/test_medrecord.py
+++ b/medmodels/medrecord/tests/test_medrecord.py
@@ -1695,7 +1695,6 @@ class TestMedRecord(unittest.TestCase):
 
         medrecord.add_group("Float")
         medrecord.add_group(1, nodes=["2", "0"])
-        # medrecord.add_group("Odd", nodes=["1", "3"])
 
         self.assertDictEqual(
             medrecord._describe_group_nodes(),
@@ -1711,9 +1710,7 @@ class TestMedRecord(unittest.TestCase):
                 "Float": {"count": 0, "attribute": {}},
                 "Ungrouped Nodes": {
                     "count": 2,
-                    "attribute": {
-                        # "amet": {"type": "Text", "values": "Values: consectetur"}
-                    },
+                    "attribute": {},
                 },
             },
         )

--- a/medmodels/medrecord/tests/test_medrecord.py
+++ b/medmodels/medrecord/tests/test_medrecord.py
@@ -1702,9 +1702,9 @@ class TestMedRecord(unittest.TestCase):
                 1: {
                     "count": 2,
                     "attribute": {
-                        "adipiscing": {"type": "Text", "values": "Values: elit"},
-                        "dolor": {"type": "Text", "values": "Values: sit"},
-                        "lorem": {"type": "Text", "values": "Values: ipsum"},
+                        "adipiscing": {"type": "Categorical", "values": "Values: elit"},
+                        "dolor": {"type": "Categorical", "values": "Values: sit"},
+                        "lorem": {"type": "Categorical", "values": "Values: ipsum"},
                     },
                 },
                 "Float": {"count": 0, "attribute": {}},
@@ -1725,7 +1725,7 @@ class TestMedRecord(unittest.TestCase):
                 "Odd": {
                     "count": 2,
                     "attribute": {
-                        "amet": {"type": "Text", "values": "Values: consectetur"}
+                        "amet": {"type": "Categorical", "values": "Values: consectetur"}
                     },
                 },
             },
@@ -1742,9 +1742,9 @@ class TestMedRecord(unittest.TestCase):
                 "Even": {
                     "count": 2,
                     "attribute": {
-                        "eiusmod": {"type": "Text", "values": "Values: tempor"},
-                        "incididunt": {"type": "Text", "values": "Values: ut"},
-                        "sed": {"type": "Text", "values": "Values: do"},
+                        "eiusmod": {"type": "Categorical", "values": "Values: tempor"},
+                        "incididunt": {"type": "Categorical", "values": "Values: ut"},
+                        "sed": {"type": "Categorical", "values": "Values: do"},
                     },
                 },
                 "Ungrouped Edges": {"count": 2, "attribute": {}},
@@ -1758,9 +1758,9 @@ class TestMedRecord(unittest.TestCase):
                 "Even": {
                     "count": 2,
                     "attribute": {
-                        "eiusmod": {"type": "Text", "values": "Values: tempor"},
-                        "incididunt": {"type": "Text", "values": "Values: ut"},
-                        "sed": {"type": "Text", "values": "Values: do"},
+                        "eiusmod": {"type": "Categorical", "values": "Values: tempor"},
+                        "incididunt": {"type": "Categorical", "values": "Values: ut"},
+                        "sed": {"type": "Categorical", "values": "Values: do"},
                     },
                 },
             },
@@ -1773,7 +1773,7 @@ class TestMedRecord(unittest.TestCase):
             "\n".join(
                 [
                     "---------------------------------------------------------------------------",
-                    "Edges Group       Count Attribute      Type       Info                     ",
+                    "Edges Group       Count Attribute      Type       Data                     ",
                     "---------------------------------------------------------------------------",
                     "patient_diagnosis 60    diagnosis_time Temporal   min: 1962-10-21 00:00:00 ",
                     "                                                  max: 2024-04-12 00:00:00 ",
@@ -1793,10 +1793,10 @@ class TestMedRecord(unittest.TestCase):
             "\n".join(
                 [
                     "-----------------------------------------------------------",
-                    "Nodes Group Count Attribute   Type        Info             ",
+                    "Nodes Group Count Attribute   Type        Data             ",
                     "-----------------------------------------------------------",
-                    "diagnosis   25    description Text        25 unique values ",
-                    "drug        19    description Text        19 unique values ",
+                    "diagnosis   25    description Categorical 25 unique values ",
+                    "drug        19    description Categorical 19 unique values ",
                     "patient     5     age         Continuous  min: 19          ",
                     "                                          max: 96          ",
                     "                                          mean: 43.20      ",

--- a/medmodels/medrecord/tests/test_medrecord.py
+++ b/medmodels/medrecord/tests/test_medrecord.py
@@ -1695,7 +1695,7 @@ class TestMedRecord(unittest.TestCase):
 
         medrecord.add_group("Float")
         medrecord.add_group(1, nodes=["2", "0"])
-        medrecord.add_group("Odd", nodes=["1", "3"])
+        # medrecord.add_group("Odd", nodes=["1", "3"])
 
         self.assertDictEqual(
             medrecord._describe_group_nodes(),
@@ -1703,20 +1703,23 @@ class TestMedRecord(unittest.TestCase):
                 1: {
                     "count": 2,
                     "attribute": {
-                        "adipiscing": {"values": "Values: elit"},
-                        "dolor": {"values": "Values: sit"},
-                        "lorem": {"values": "Values: ipsum"},
+                        "adipiscing": {"type": "Text", "values": "Values: elit"},
+                        "dolor": {"type": "Text", "values": "Values: sit"},
+                        "lorem": {"type": "Text", "values": "Values: ipsum"},
                     },
                 },
                 "Float": {"count": 0, "attribute": {}},
-                "Odd": {
+                "Ungrouped Nodes": {
                     "count": 2,
-                    "attribute": {"amet": {"values": "Values: consectetur"}},
+                    "attribute": {
+                        # "amet": {"type": "Text", "values": "Values: consectetur"}
+                    },
                 },
             },
         )
 
         # test group input list
+        medrecord.add_group("Odd", nodes=["1", "3"])
 
         self.assertDictEqual(
             medrecord._describe_group_nodes(groups=["Float", "Odd"]),
@@ -1724,7 +1727,9 @@ class TestMedRecord(unittest.TestCase):
                 "Float": {"count": 0, "attribute": {}},
                 "Odd": {
                     "count": 2,
-                    "attribute": {"amet": {"values": "Values: consectetur"}},
+                    "attribute": {
+                        "amet": {"type": "Text", "values": "Values: consectetur"}
+                    },
                 },
             },
         )
@@ -1740,9 +1745,9 @@ class TestMedRecord(unittest.TestCase):
                 "Even": {
                     "count": 2,
                     "attribute": {
-                        "eiusmod": {"values": "Values: tempor"},
-                        "incididunt": {"values": "Values: ut"},
-                        "sed": {"values": "Values: do"},
+                        "eiusmod": {"type": "Text", "values": "Values: tempor"},
+                        "incididunt": {"type": "Text", "values": "Values: ut"},
+                        "sed": {"type": "Text", "values": "Values: do"},
                     },
                 },
                 "Ungrouped Edges": {"count": 2, "attribute": {}},
@@ -1756,12 +1761,53 @@ class TestMedRecord(unittest.TestCase):
                 "Even": {
                     "count": 2,
                     "attribute": {
-                        "eiusmod": {"values": "Values: tempor"},
-                        "incididunt": {"values": "Values: ut"},
-                        "sed": {"values": "Values: do"},
+                        "eiusmod": {"type": "Text", "values": "Values: tempor"},
+                        "incididunt": {"type": "Text", "values": "Values: ut"},
+                        "sed": {"type": "Text", "values": "Values: do"},
                     },
                 },
             },
+        )
+
+    def test_overview_edges(self):
+        medrecord = MedRecord.from_example_dataset()
+
+        self.assertEqual(
+            "\n".join(
+                [
+                    "---------------------------------------------------------------------------",
+                    "Edges Group       Count Attribute      Type       Info                     ",
+                    "---------------------------------------------------------------------------",
+                    "patient_diagnosis 60    diagnosis_time Temporal   min: 1962-10-21 00:00:00 ",
+                    "                                                  max: 2024-04-12 00:00:00 ",
+                    "                        duration_days  Continuous min: 0.00                ",
+                    "                                                  max: 3416.00             ",
+                    "                                                  mean: 405.02             ",
+                    "---------------------------------------------------------------------------",
+                ]
+            ),
+            str(medrecord.overview_edges("patient_diagnosis")),
+        )
+
+    def test_overview_nodes(self):
+        medrecord = MedRecord.from_example_dataset()
+
+        self.assertEqual(
+            "\n".join(
+                [
+                    "-----------------------------------------------------------",
+                    "Nodes Group Count Attribute   Type        Info             ",
+                    "-----------------------------------------------------------",
+                    "diagnosis   25    description Text        25 unique values ",
+                    "drug        19    description Text        19 unique values ",
+                    "patient     5     age         Continuous  min: 19          ",
+                    "                                          max: 96          ",
+                    "                                          mean: 43.20      ",
+                    "                  gender      Categorical Categories: F, M ",
+                    "-----------------------------------------------------------",
+                ]
+            ),
+            str(medrecord.overview_nodes(["diagnosis", "drug", "patient"])),
         )
 
 

--- a/medmodels/medrecord/tests/test_medrecord.py
+++ b/medmodels/medrecord/tests/test_medrecord.py
@@ -1716,6 +1716,19 @@ class TestMedRecord(unittest.TestCase):
             },
         )
 
+        # test group input list
+
+        self.assertDictEqual(
+            medrecord._describe_group_nodes(groups=["Float", "Odd"]),
+            {
+                "Float": {"count": 0, "attribute": {}},
+                "Odd": {
+                    "count": 2,
+                    "attribute": {"amet": {"values": "Values: consectetur"}},
+                },
+            },
+        )
+
     def test_describe_group_edges(self):
         medrecord = create_medrecord()
 
@@ -1733,6 +1746,21 @@ class TestMedRecord(unittest.TestCase):
                     },
                 },
                 "Ungrouped Edges": {"count": 2, "attribute": {}},
+            },
+        )
+
+        # test the specified group list
+        self.assertDictEqual(
+            medrecord._describe_group_edges(groups=["Even"]),
+            {
+                "Even": {
+                    "count": 2,
+                    "attribute": {
+                        "eiusmod": {"values": "Values: tempor"},
+                        "incididunt": {"values": "Values: ut"},
+                        "sed": {"values": "Values: do"},
+                    },
+                },
             },
         )
 

--- a/medmodels/medrecord/tests/test_overview.py
+++ b/medmodels/medrecord/tests/test_overview.py
@@ -97,7 +97,9 @@ class TestOverview(unittest.TestCase):
         # numeric type
         numeric_attribute = extract_attribute_summary(medrecord.node[query2])
 
-        numeric_expected = {"age": {"min": 20, "max": 70, "mean": 40.0}}
+        numeric_expected = {
+            "age": {"type": "Continuous", "min": 20, "max": 70, "mean": 40.0}
+        }
 
         self.assertDictEqual(numeric_attribute, numeric_expected)
 
@@ -108,7 +110,8 @@ class TestOverview(unittest.TestCase):
         str_attributes = extract_attribute_summary(medrecord.node[query3])
 
         self.assertDictEqual(
-            str_attributes, {"ATC": {"values": "Values: B01AA03, B01AF01"}}
+            str_attributes,
+            {"ATC": {"type": "Text", "values": "Values: B01AA03, B01AF01"}},
         )
 
         def query4(node: NodeOperand):
@@ -117,7 +120,7 @@ class TestOverview(unittest.TestCase):
         # nan attribute
         nan_attributes = extract_attribute_summary(medrecord.node[query4])
 
-        self.assertDictEqual(nan_attributes, {"ATC": {"values": "-"}})
+        self.assertDictEqual(nan_attributes, {"ATC": {"type": "-", "values": "-"}})
 
         def query5(edge: EdgeOperand):
             edge.source_node().in_group("Medications")
@@ -130,6 +133,7 @@ class TestOverview(unittest.TestCase):
             temp_attributes,
             {
                 "time": {
+                    "type": "Temporal",
                     "max": datetime(2000, 1, 1, 0, 0),
                     "min": datetime(1999, 10, 15, 0, 0),
                 }
@@ -148,10 +152,11 @@ class TestOverview(unittest.TestCase):
             mixed_attributes,
             {
                 "time": {
+                    "type": "Temporal",
                     "min": datetime(1999, 12, 15, 0, 0),
                     "max": datetime(2000, 1, 1, 0, 0),
                 },
-                "intensity": {"values": "Values: 1, low"},
+                "intensity": {"type": "Text", "values": "Values: 1, low"},
             },
         )
 
@@ -167,8 +172,8 @@ class TestOverview(unittest.TestCase):
         self.assertDictEqual(
             node_info,
             {
-                "age": {"min": 19, "max": 96, "mean": 43.20},
-                "gender": {"values": "Categories: F, M"},
+                "age": {"type": "Continuous", "min": 19, "max": 96, "mean": 43.20},
+                "gender": {"type": "Categorical", "values": "Categories: F, M"},
             },
         )
 
@@ -185,10 +190,12 @@ class TestOverview(unittest.TestCase):
             patient_diagnosis,
             {
                 "diagnosis_time": {
+                    "type": "Temporal",
                     "min": datetime(1962, 10, 21, 0, 0),
                     "max": datetime(2024, 4, 12, 0, 0),
                 },
                 "duration_days": {
+                    "type": "Continuous",
                     "min": 0.0,
                     "max": 3416.0,
                     "mean": 405.0232558139535,
@@ -199,20 +206,20 @@ class TestOverview(unittest.TestCase):
     def test_prettify_table(self):
         medrecord = create_medrecord()
 
-        header = ["group nodes", "count", "attribute", "info"]
+        header = ["group nodes", "count", "attribute", "type", "info"]
 
         expected_nodes = [
-            "---------------------------------------------------------",
-            "Group Nodes     Count Attribute Info                     ",
-            "---------------------------------------------------------",
-            "Aspirin         1     ATC       -                        ",
-            "Medications     3     ATC       Values: B01AA03, B01AF01 ",
-            "Patients        3     age       min: 20                  ",
-            "                                max: 70                  ",
-            "                                mean: 40.00              ",
-            "Stroke          1     -         -                        ",
-            "Ungrouped Nodes 1     -         -                        ",
-            "---------------------------------------------------------",
+            "--------------------------------------------------------------------",
+            "Group Nodes     Count Attribute Type       Info                     ",
+            "--------------------------------------------------------------------",
+            "Aspirin         1     ATC       -          -                        ",
+            "Medications     3     ATC       Text       Values: B01AA03, B01AF01 ",
+            "Patients        3     age       Continuous min: 20                  ",
+            "                                           max: 70                  ",
+            "                                           mean: 40.00              ",
+            "Stroke          1     -         -          -                        ",
+            "Ungrouped Nodes 1     -         -          -                        ",
+            "--------------------------------------------------------------------",
         ]
 
         self.assertEqual(
@@ -220,16 +227,16 @@ class TestOverview(unittest.TestCase):
             expected_nodes,
         )
 
-        header = ["group edges", "count", "attribute", "info"]
+        header = ["group edges", "count", "attribute", "type", "info"]
 
         expected_edges = [
-            "-------------------------------------------------------------",
-            "Group Edges         Count Attribute Info                     ",
-            "-------------------------------------------------------------",
-            "patient-medications 3     time      min: 1999-10-15 00:00:00 ",
-            "                                    max: 2000-01-01 00:00:00 ",
-            "Ungrouped Edges     6     -         -                        ",
-            "-------------------------------------------------------------",
+            "----------------------------------------------------------------------",
+            "Group Edges         Count Attribute Type     Info                     ",
+            "----------------------------------------------------------------------",
+            "patient-medications 3     time      Temporal min: 1999-10-15 00:00:00 ",
+            "                                             max: 2000-01-01 00:00:00 ",
+            "Ungrouped Edges     6     -         -        -                        ",
+            "----------------------------------------------------------------------",
         ]
 
         self.assertEqual(

--- a/medmodels/medrecord/tests/test_overview.py
+++ b/medmodels/medrecord/tests/test_overview.py
@@ -111,7 +111,7 @@ class TestOverview(unittest.TestCase):
 
         self.assertDictEqual(
             str_attributes,
-            {"ATC": {"type": "Text", "values": "Values: B01AA03, B01AF01"}},
+            {"ATC": {"type": "Categorical", "values": "Values: B01AA03, B01AF01"}},
         )
 
         def query4(node: NodeOperand):
@@ -156,7 +156,7 @@ class TestOverview(unittest.TestCase):
                     "min": datetime(1999, 12, 15, 0, 0),
                     "max": datetime(2000, 1, 1, 0, 0),
                 },
-                "intensity": {"type": "Text", "values": "Values: 1, low"},
+                "intensity": {"type": "Categorical", "values": "Values: 1, low"},
             },
         )
 
@@ -209,17 +209,17 @@ class TestOverview(unittest.TestCase):
         header = ["group nodes", "count", "attribute", "type", "info"]
 
         expected_nodes = [
-            "--------------------------------------------------------------------",
-            "Group Nodes     Count Attribute Type       Info                     ",
-            "--------------------------------------------------------------------",
-            "Aspirin         1     ATC       -          -                        ",
-            "Medications     3     ATC       Text       Values: B01AA03, B01AF01 ",
-            "Patients        3     age       Continuous min: 20                  ",
-            "                                           max: 70                  ",
-            "                                           mean: 40.00              ",
-            "Stroke          1     -         -          -                        ",
-            "Ungrouped Nodes 1     -         -          -                        ",
-            "--------------------------------------------------------------------",
+            "---------------------------------------------------------------------",
+            "Group Nodes     Count Attribute Type        Info                     ",
+            "---------------------------------------------------------------------",
+            "Aspirin         1     ATC       -           -                        ",
+            "Medications     3     ATC       Categorical Values: B01AA03, B01AF01 ",
+            "Patients        3     age       Continuous  min: 20                  ",
+            "                                            max: 70                  ",
+            "                                            mean: 40.00              ",
+            "Stroke          1     -         -           -                        ",
+            "Ungrouped Nodes 1     -         -           -                        ",
+            "---------------------------------------------------------------------",
         ]
 
         self.assertEqual(

--- a/medmodels/medrecord/tests/test_overview.py
+++ b/medmodels/medrecord/tests/test_overview.py
@@ -59,6 +59,19 @@ def create_medrecord():
 
     medrecord.add_edges_polars(edges=(edges_disease, "source", "target"))
 
+    edges_meds = pd.DataFrame(
+        {
+            "source": ["M1", "M2", "M3"],
+            "target": ["P1", "P2", "P3"],
+            "time": ["2000-01-01", "1999-10-15", "1999-12-15"],
+        }
+    )
+    edges_meds["time"] = pd.to_datetime(edges_meds["time"])
+
+    medrecord.add_edges_pandas(
+        edges=(edges_meds, "source", "target"), group="patient-medications"
+    )
+
     for group, group_list in groups:
         medrecord.add_group(group, group_list)
 
@@ -117,7 +130,7 @@ class TestOverview(unittest.TestCase):
             temp_attributes,
             {
                 "time": {
-                    "max": datetime(1999, 10, 15, 0, 0),
+                    "max": datetime(2000, 1, 1, 0, 0),
                     "min": datetime(1999, 10, 15, 0, 0),
                 }
             },
@@ -188,7 +201,7 @@ class TestOverview(unittest.TestCase):
 
         header = ["group nodes", "count", "attribute", "info"]
 
-        expected_empty = [
+        expected_nodes = [
             "---------------------------------------------------------",
             "Group Nodes     Count Attribute Info                     ",
             "---------------------------------------------------------",
@@ -204,7 +217,24 @@ class TestOverview(unittest.TestCase):
 
         self.assertEqual(
             prettify_table(medrecord._describe_group_nodes(), header, decimal=2),
-            expected_empty,
+            expected_nodes,
+        )
+
+        header = ["group edges", "count", "attribute", "info"]
+
+        expected_edges = [
+            "-------------------------------------------------------------",
+            "Group Edges         Count Attribute Info                     ",
+            "-------------------------------------------------------------",
+            "patient-medications 3     time      min: 1999-10-15 00:00:00 ",
+            "                                    max: 2000-01-01 00:00:00 ",
+            "Ungrouped Edges     6     -         -                        ",
+            "-------------------------------------------------------------",
+        ]
+
+        self.assertEqual(
+            prettify_table(medrecord._describe_group_edges(), header, decimal=2),
+            expected_edges,
         )
 
 

--- a/medmodels/medrecord/types.py
+++ b/medmodels/medrecord/types.py
@@ -128,6 +128,7 @@ class AttributeInfo(TypedDict):
 class TemporalAttributeInfo(TypedDict):
     """Dictionary for a temporal attribute and its metrics."""
 
+    type: str
     min: datetime
     max: datetime
 
@@ -135,6 +136,7 @@ class TemporalAttributeInfo(TypedDict):
 class NumericAttributeInfo(TypedDict):
     """Dictionary for a numeric attribute and its metrics."""
 
+    type: str
     min: Union[int, float]
     max: Union[int, float]
     mean: Union[int, float]
@@ -143,6 +145,7 @@ class NumericAttributeInfo(TypedDict):
 class StringAttributeInfo(TypedDict):
     """Dictionary for a string attribute and its values."""
 
+    type: str
     values: str
 
 

--- a/medmodels/medrecord/types.py
+++ b/medmodels/medrecord/types.py
@@ -1,7 +1,17 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Dict, List, Mapping, Sequence, Tuple, TypedDict, Union
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    List,
+    Literal,
+    Mapping,
+    Sequence,
+    Tuple,
+    TypedDict,
+    Union,
+)
 
 import pandas as pd
 import polars as pl
@@ -128,7 +138,7 @@ class AttributeInfo(TypedDict):
 class TemporalAttributeInfo(TypedDict):
     """Dictionary for a temporal attribute and its metrics."""
 
-    type: str
+    type: Literal["Temporal"]
     min: datetime
     max: datetime
 
@@ -136,7 +146,7 @@ class TemporalAttributeInfo(TypedDict):
 class NumericAttributeInfo(TypedDict):
     """Dictionary for a numeric attribute and its metrics."""
 
-    type: str
+    type: Literal["Continuous"]
     min: Union[int, float]
     max: Union[int, float]
     mean: Union[int, float]
@@ -145,7 +155,7 @@ class NumericAttributeInfo(TypedDict):
 class StringAttributeInfo(TypedDict):
     """Dictionary for a string attribute and its values."""
 
-    type: str
+    type: Literal["Categorical"]
     values: str
 
 


### PR DESCRIPTION
Closes Ticket #260 

Added Input parameter `groups` to `overview_edges()` and `overview_nodes()` to only show specified groups.
Also fixed key word min/max showing for temporal attributes.

Updated tests. 