### PR TITLE
refactor: fast-computed representation of the MedRecord when in debugging mode

### DIFF
--- a/medmodels/medrecord/medrecord.py
+++ b/medmodels/medrecord/medrecord.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import Callable, Dict, List, Optional, Sequence, Union, overload
 
 import polars as pl
@@ -1351,6 +1352,10 @@ class MedRecord:
         return edges_info
 
     def __repr__(self) -> str:
+        # If in debugging mode, avoid computing the whole representation
+        if sys.gettrace() is not None:
+            return f"<MedRecord: {self.node_count()} nodes, {self.edge_count()} edges>"
+
         return "\n".join([str(self.overview_nodes()), "", str(self.overview_edges())])
 
     def overview_nodes(self, decimal: int = 2) -> OverviewTable:


### PR DESCRIPTION
The MedRecord can have loads of different nodes and groups, so going through their attributes can be very slow work. This can hinder the performance of the MedRecord in debugging mode. For that reason, a short representation of the MedRecord will be shown in debugging mode> 

`<MedRecord: 73 nodes, 160 edges>`