### PR TITLE
chore: Drop support for python 3.9 and add support for 3.13

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://black.readthedocs.io/en/stable/">
     <img alt="Code Style" src="https://img.shields.io/badge/code_style-black-black.svg">
   </a>
-  <img alt="Python Versions" src="https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue">
+  <img alt="Python Versions" src="https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue">
   <a href="https://github.com/limebit/medmodels/blob/main/LICENSE">
     <img alt="MedModels License" src="https://img.shields.io/github/license/limebit/medmodels.svg">
   </a>

--- a/docs/developer_guide/setup.md
+++ b/docs/developer_guide/setup.md
@@ -4,7 +4,7 @@ MedModels leverages a combination of Python and Rust code. To contribute effecti
 
 **Requirements:**
 
-- Python (3.9, 3.10, 3.11 or 3.12)
+- Python (3.10, 3.11, 3.12 or 3.13)
 - Rust compiler (follow instructions from [https://www.rust-lang.org/tools/install](https://www.rust-lang.org/tools/install))
 
 **Using the Makefile:**

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,7 +65,7 @@ API Reference
 
 ```{only} html
 [![black](https://img.shields.io/badge/code_style-black-black.svg)](https://black.readthedocs.io/en/stable/)
-![python versions](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)
+![python versions](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)
 [![license](https://img.shields.io/github/license/limebit/medmodels.svg)](https://github.com/limebit/medmodels/blob/main/LICENSE)
 [![license](https://github.com/limebit/medmodels/actions/workflows/testing.yml/badge.svg?branch=main)](https://github.com/limebit/medmodels/actions/workflows/testing.yml)
 ```

--- a/medmodels/_medmodels.pyi
+++ b/medmodels/_medmodels.pyi
@@ -1,6 +1,5 @@
-import sys
 from enum import Enum
-from typing import Callable, Dict, List, Optional, Sequence, Union
+from typing import Callable, Dict, List, Optional, Sequence, TypeAlias, Union
 
 from medmodels.medrecord.types import (
     Attributes,
@@ -18,11 +17,6 @@ from medmodels.medrecord.types import (
     PolarsEdgeDataFrameInput,
     PolarsNodeDataFrameInput,
 )
-
-if sys.version_info >= (3, 10):
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
 
 PyDataType: TypeAlias = Union[
     PyString,

--- a/medmodels/medrecord/_overview.py
+++ b/medmodels/medrecord/_overview.py
@@ -9,10 +9,14 @@ from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
 import polars as pl
 
 from medmodels.medrecord.schema import AttributesSchema, AttributeType
-from medmodels.medrecord.types import Attributes, EdgeIndex, NodeIndex
+from medmodels.medrecord.types import (
+    Attributes,
+    EdgeIndex,
+    NodeIndex,
+)
 
 if TYPE_CHECKING:
-    import sys
+    from typing import TypeAlias
 
     from medmodels.medrecord.types import (
         AttributeInfo,
@@ -22,11 +26,6 @@ if TYPE_CHECKING:
         StringAttributeInfo,
         TemporalAttributeInfo,
     )
-
-    if sys.version_info >= (3, 10):
-        from typing import TypeAlias
-    else:
-        from typing_extensions import TypeAlias
 
 AttributeDictionary: TypeAlias = Union[
     Dict[EdgeIndex, Attributes], Dict[NodeIndex, Attributes]

--- a/medmodels/medrecord/builder.py
+++ b/medmodels/medrecord/builder.py
@@ -4,11 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
-if TYPE_CHECKING:
-    from typing_extensions import TypeIs
-
-    from medmodels.medrecord.schema import Schema
-
 import medmodels as mm
 from medmodels.medrecord.types import (
     EdgeTuple,
@@ -33,6 +28,11 @@ from medmodels.medrecord.types import (
     is_polars_node_dataframe_input,
     is_polars_node_dataframe_input_list,
 )
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeIs
+
+    from medmodels.medrecord.schema import Schema
 
 NodeInputBuilder = Union[
     NodeTuple,

--- a/medmodels/medrecord/datatype.py
+++ b/medmodels/medrecord/datatype.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import typing
 from abc import ABC, abstractmethod
+from typing import TypeAlias
 
 from medmodels._medmodels import (
     PyAny,
@@ -17,14 +18,6 @@ from medmodels._medmodels import (
     PyString,
     PyUnion,
 )
-
-if typing.TYPE_CHECKING:
-    import sys
-
-    if sys.version_info >= (3, 10):
-        from typing import TypeAlias
-    else:
-        from typing_extensions import TypeAlias
 
 PyDataType: TypeAlias = typing.Union[
     PyString,

--- a/medmodels/medrecord/querying.py
+++ b/medmodels/medrecord/querying.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import TYPE_CHECKING, Callable, List, Union
+from typing import Callable, List, TypeAlias, Union
 
 from medmodels._medmodels import (
     PyAttributesTreeOperand,
@@ -26,14 +26,6 @@ from medmodels.medrecord.types import (
     MedRecordValue,
     NodeIndex,
 )
-
-if TYPE_CHECKING:
-    import sys
-
-    if sys.version_info >= (3, 10):
-        from typing import TypeAlias
-    else:
-        from typing_extensions import TypeAlias
 
 NodeQuery: TypeAlias = Callable[["NodeOperand"], None]
 EdgeQuery: TypeAlias = Callable[["EdgeOperand"], None]

--- a/medmodels/medrecord/types.py
+++ b/medmodels/medrecord/types.py
@@ -11,6 +11,7 @@ from typing import (
     Mapping,
     Sequence,
     Tuple,
+    TypeAlias,
     TypedDict,
     Union,
 )
@@ -19,14 +20,7 @@ import pandas as pd
 import polars as pl
 
 if TYPE_CHECKING:
-    import sys
-
-    if sys.version_info >= (3, 10):
-        from typing import TypeAlias
-
-        from typing_extensions import TypeIs
-    else:
-        from typing_extensions import TypeAlias, TypeIs
+    from typing_extensions import TypeIs
 
 #: A type alias for attributes of a medical record.
 MedRecordAttribute: TypeAlias = Union[str, int]

--- a/medmodels/treatment_effect/continuous_estimators.py
+++ b/medmodels/treatment_effect/continuous_estimators.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
     from medmodels.medrecord.querying import EdgeOperand
     from medmodels.medrecord.types import Group, MedRecordAttribute, NodeIndex
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/medmodels/treatment_effect/matching/algorithms/propensity_score.py
+++ b/medmodels/treatment_effect/matching/algorithms/propensity_score.py
@@ -9,7 +9,7 @@ two groups are comparable.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Tuple, TypeAlias, Union
 
 import numpy as np
 import polars as pl
@@ -22,17 +22,9 @@ from medmodels.treatment_effect.matching.algorithms.classic_distance_models impo
 )
 
 if TYPE_CHECKING:
-    import sys
-
     from numpy.typing import NDArray
 
     from medmodels.medrecord.types import MedRecordAttributeInputList
-
-    if sys.version_info >= (3, 10):
-        from typing import TypeAlias
-    else:
-        from typing_extensions import TypeAlias
-
 
 Model: TypeAlias = Literal["logit", "dec_tree", "forest"]
 

--- a/medmodels/treatment_effect/matching/matching.py
+++ b/medmodels/treatment_effect/matching/matching.py
@@ -8,20 +8,13 @@ score matching and nearest neighbor matching.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Literal, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Literal, Optional, Set, Tuple, TypeAlias
 
 import polars as pl
 
 if TYPE_CHECKING:
-    import sys
-
     from medmodels.medrecord.medrecord import MedRecord
     from medmodels.medrecord.types import MedRecordAttributeInputList, NodeIndex
-
-    if sys.version_info >= (3, 10):
-        from typing import TypeAlias
-    else:
-        from typing_extensions import TypeAlias
 
 MatchingMethod: TypeAlias = Literal["propensity", "nearest_neighbors"]
 

--- a/medmodels/treatment_effect/tests/test_temporal_analysis.py
+++ b/medmodels/treatment_effect/tests/test_temporal_analysis.py
@@ -8,7 +8,6 @@ import pandas as pd
 import pytest
 
 from medmodels.medrecord.medrecord import MedRecord
-from medmodels.medrecord.types import NodeIndex
 from medmodels.treatment_effect.temporal_analysis import find_reference_edge
 
 if TYPE_CHECKING:

--- a/medmodels/treatment_effect/treatment_effect.py
+++ b/medmodels/treatment_effect/treatment_effect.py
@@ -41,16 +41,6 @@ if TYPE_CHECKING:
     from medmodels.treatment_effect.matching.algorithms.propensity_score import Model
     from medmodels.treatment_effect.matching.matching import MatchingMethod
 
-if TYPE_CHECKING:
-    from medmodels import MedRecord
-    from medmodels.medrecord.types import (
-        Group,
-        MedRecordAttribute,
-        MedRecordAttributeInputList,
-        NodeIndex,
-    )
-    from medmodels.treatment_effect.matching.algorithms.propensity_score import Model
-    from medmodels.treatment_effect.matching.matching import MatchingMethod
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "medmodels"
 version = "0.1.2"
 description = "Limebit Medmodels Package"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     'Development Status :: 3 - Alpha',
     'Intended Audience :: Developers',
@@ -16,10 +16,10 @@ classifiers = [
     'Operating System :: Unix',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: 3 :: Only',
     'Programming Language :: Rust',
     'Topic :: Scientific/Engineering',


### PR DESCRIPTION
Removed python 3.9 from the supported list and refactored code to no longer inclue the sys.version checks. Also added support for python 3.13