### PR TITLE
fix: docs build error

### DIFF
--- a/docs/developer_guide/docstrings.md
+++ b/docs/developer_guide/docstrings.md
@@ -31,11 +31,11 @@ Example:
 
 ```{literalinclude} example_docstrings.py
 :lines: 1-5, 6-38
-:emphasize-lines: 13
+:emphasize-lines: 15
 ```
 
 :::{admonition} No Linebreaks In Summary Line
-:type: note
+:class: note
 The summary line cannot contain line breaks and must not exceed the maximum line length. Ensure that the summary line provides a brief description of the function's purpose. Further explanation and details can be given in the [Description](#description) text block underneath.
 :::
 
@@ -216,11 +216,11 @@ Example:
 
 ```{literalinclude} example_docstrings.py
 :lines: 1-5, 6-38
-:emphasize-lines: 18-26
+:emphasize-lines: 20-28
 ```
 
 :::{admonition} No Linebreak in Type Definitions
-:type: note
+:class: note
 
 When writing type definitions in argument docstrings, avoid placing line breaks inside the type annotations. For instance, complex types like `(Union[str, List[str], Dict[str, Any]])` should appear on a single line without splitting across lines. This ensures the type definition remains clear and avoids parsing issues.
 
@@ -228,7 +228,7 @@ If a type definition exceeds the maximum line length limit, deactivate the line 
 :::
 
 :::{admonition} No Boolean Argument Types
-:type: note
+:class: note
 Avoid using booleans as function arguments due to the "boolean trap". Booleans reduce code clarity, as `True` or `False` doesn't explain meaning. They also limit future flexibility — if more than two options are needed, changing the argument type can cause breaking changes. Instead, use an enum or a more descriptive type for better clarity and flexibility.
 
 For more information, you can refer to [Adam Johnson's article](https://adamj.eu/tech/2021/07/10/python-type-hints-how-to-avoid-the-boolean-trap/) which discusses this in detail and provides examples of how to avoid the boolean trap.
@@ -250,7 +250,7 @@ def example_function(param1, param2):
 ```
 
 :::{admonition} Don't Document `None` Return Value
-:type: note
+:class: note
 Don't add a `Returns` section when the function has no return value (`def fun() -> None`)
 :::
 
@@ -333,7 +333,7 @@ Will be shown in the API Docs as:
 ```
 ````
 
-Check out the docs of [find_node_in_time_window()](medmodels.treatment_effect.temporal_analysis.find_node_in_time_window) for a real example.
+Check out the docs of [find_reference_edge()](medmodels.treatment_effect.temporal_analysis.find_reference_edge) for a real example.
 
 ### Raises
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,10 +64,11 @@ API Reference
 ````
 
 ```{only} html
-[![black](https://img.shields.io/badge/code_style-black-black.svg)](https://black.readthedocs.io/en/stable/)
+[![ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 ![python versions](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)
 [![license](https://img.shields.io/github/license/limebit/medmodels.svg)](https://github.com/limebit/medmodels/blob/main/LICENSE)
 [![license](https://github.com/limebit/medmodels/actions/workflows/testing.yml/badge.svg?branch=main)](https://github.com/limebit/medmodels/actions/workflows/testing.yml)
+[![PyPI](https://img.shields.io/pypi/v/medmodels)](https://pypi.org/project/medmodels/)
 ```
 
 :::

--- a/medmodels/medrecord/medrecord.py
+++ b/medmodels/medrecord/medrecord.py
@@ -1432,18 +1432,18 @@ class MedRecord:
             OverviewTable: Display of edge groups and their attributes.
 
         Example:
+            .. code-block:: text
 
-        --------------------------------------------------------------
-        Nodes Group     Count Attribute   Type        Data
-        --------------------------------------------------------------
-        diagnosis       25    description Categorical 25 unique values
-        patient         5     age         Continuous  min: 19
-                                                      max: 96
-                                                      mean: 43.20
-                              gender      Categorical Categories: F, M
-        Ungrouped Nodes 10    -           -           -
-        --------------------------------------------------------------
-
+                --------------------------------------------------------------
+                Nodes Group     Count Attribute   Type        Data
+                --------------------------------------------------------------
+                diagnosis       25    description Categorical 25 unique values
+                patient         5     age         Continuous  min: 19
+                                                              max: 96
+                                                              mean: 43.20
+                                      gender      Categorical Categories: F, M
+                Ungrouped Nodes 10    -           -           -
+                --------------------------------------------------------------
         """
         if groups:
             nodes_data = self._describe_group_nodes(
@@ -1472,17 +1472,19 @@ class MedRecord:
             OverviewTable: Display of edge groups and their attributes.
 
         Example:
+            .. code-block:: text
 
-        --------------------------------------------------------------------------
-        Edges Group       Count Attribute      Type       Data
-        --------------------------------------------------------------------------
-        Patient-Diagnosis 60    diagnosis_time Temporal   min: 1962-10-21 00:00:00
-                                                          max: 2024-04-12 00:00:00
-                                duration_days  Continuous min: 0
-                                                          max: 3416
-                                                          mean: 405.02
-        --------------------------------------------------------------------------
-        """
+                --------------------------------------------------------------------------
+                Edges Group       Count Attribute      Type       Data
+                --------------------------------------------------------------------------
+                Patient-Diagnosis 60    diagnosis_time Temporal   min: 1962-10-21 00:00:00
+                                                                  max: 2024-04-12 00:00:00
+                                        duration_days  Continuous min: 0
+                                                                  max: 3416
+                                                                  mean: 405.02
+                --------------------------------------------------------------------------
+
+        """  # noqa: W505
         if groups:
             edges_data = self._describe_group_edges(
                 groups if isinstance(groups, list) else [groups]

--- a/medmodels/medrecord/querying.py
+++ b/medmodels/medrecord/querying.py
@@ -218,16 +218,19 @@ class NodeOperand:
         It is used to query the edges connecting the nodes defined after this node
         operand, having the direction specified.
 
-        Example:
-        ```python
-            node_operand.edges(EdgeDirection.OUTGOING).attribute("weight").greater_than(10)
-        ```
         Args:
             direction (EdgeDirection): The direction of the edges to consider.
                 Defaults to EdgeDirection.BOTH.
 
         Returns:
             EdgeOperand: The edges connecting the nodes defined after this node operand.
+
+        Example:
+
+            .. highlight:: python
+            .. code-block:: python
+
+                node_operand.edges(EdgeDirection.OUTGOING).attribute("weight").greater_than(10)
         """
         return EdgeOperand._from_py_edge_operand(
             self._node_operand.edges(direction._into_py_edge_direction())
@@ -241,17 +244,20 @@ class NodeOperand:
         It is used to query the nodes that have an edge connecting them to the
         neighbors defined after this node operand.
 
-        Example:
-        ```python
-            node_operand.neighbors(EdgeDirection.OUTGOING).in_group(patients_group)
-        ```
-
         Args:
             edge_direction (EdgeDirection): The direction of the edges to consider.
                 Defaults to EdgeDirection.OUTGOING.
 
         Returns:
             NodeOperand: The neighbors of the current node query.
+
+        Example:
+
+            .. highlight:: python
+            .. code-block:: python
+
+                node_operand.neighbors(EdgeDirection.OUTGOING).in_group(patients_group)
+
         """
         return NodeOperand._from_py_node_operand(
             self._node_operand.neighbors(edge_direction._into_py_edge_direction())
@@ -263,19 +269,19 @@ class NodeOperand:
         It applies the combination of the two queries to the node query. It returns all
         nodes that satisfy either the first query or the second query.
 
-        Example:
-         ```python
-
-        node_operand.either_or(
-            lambda node: node.attribute("age").greater_than(10),
-            lambda node: node.attribute("age").less_than(10)
-        )
-
-        ```
-
         Args:
             either (Callable[[EdgeIndexOperand], None]): One of the queries to apply.
             or_ (Callable[[EdgeIndexOperand], None]): The other query to apply.
+
+        Example:
+
+            .. highlight:: python
+            .. code-block:: python
+
+                node_operand.either_or(
+                    lambda node: node.attribute("age").greater_than(10),
+                    lambda node: node.attribute("age").less_than(10),
+                )
         """
         self._node_operand.either_or(
             lambda node: either(NodeOperand._from_py_node_operand(node)),
@@ -388,17 +394,21 @@ class EdgeOperand:
         This method applies the combination of the two queries to the edge query. It
         returns all edges that satisfy either the first query or the second query.
 
-        Example:
-        ```python
-        edge_operand.either_or(
-            lambda edge: edge.source_node().in_group("group1"),
-            lambda edge: edge.target_node().in_group("group1"),
-        )
-        ```
-
         Args:
             either (Callable[[EdgeIndexOperand], None]): One of the queries to apply.
             or_ (Callable[[EdgeIndexOperand], None]): The other query to apply.
+
+        Example:
+
+            .. highlight:: python
+            .. code-block:: python
+
+                edge_operand.either_or(
+                    lambda edge: edge.source_node().in_group("group1"),
+                    lambda edge: edge.target_node().in_group("group1"),
+                )
+
+
         """
         self._edge_operand.either_or(
             lambda edge: either(EdgeOperand._from_py_edge_operand(edge)),
@@ -871,17 +881,19 @@ class MultipleValuesOperand:
         query. It returns all multiple values that satisfy either the first query or the
         second query.
 
-        Example:
-        ```python
-        multiple_values_operand.either_or(
-            lambda values: values.is_int(), lambda values: values.is_float()
-        )
-        ```
-
         Args:
             either (Callable[[MultipleValuesOperand], None]): One of the queries to
                 apply.
             or_ (Callable[[MultipleValuesOperand], None]): The other query to apply.
+
+        Example:
+            .. highlight:: python
+            .. code-block:: python
+
+                multiple_values_operand.either_or(
+                    lambda values: values.is_int(), lambda values: values.is_float()
+                )
+
         """
         self._multiple_values_operand.either_or(
             lambda values: either(
@@ -1228,16 +1240,18 @@ class SingleValueOperand:
         query. It returns all single values that satisfy either the first query or the
         second query.
 
-        Example:
-        ```python
-        single_value_operand.either_or(
-            lambda value: value.is_int(), lambda value: value.is_float()
-        )
-        ```
-
         Args:
             either (Callable[[SingleValueOperand], None]): One of the queries to apply.
             or_ (Callable[[SingleValueOperand], None]): The other query to apply.
+
+        Example:
+            .. highlight:: python
+            .. code-block:: python
+
+                single_value_operand.either_or(
+                    lambda value: value.is_int(), lambda value: value.is_float()
+                )
+
         """
         self._single_value_operand.either_or(
             lambda value: either(
@@ -1632,21 +1646,24 @@ class AttributesTreeOperand:
         attribute names that satisfy either the first query or the second query for
         each node/edge.
 
-        Example:
-            ```python
-            # Example usage of either_or logic to filter attributes
-            attributes_tree_operand.either_or(
-                lambda attributes: attributes.is_int(),  # Query for integer attributes
-                lambda attributes: attributes.is_float(),  # Query for float attributes
-            )
-            ```
-
         Args:
             either (Callable[[AttributesTreeOperand], None]): A query function to
                 evaluate one condition on the attributes.
             or_ (Callable[[AttributesTreeOperand], None]): A query function to evaluate
                 the alternative condition on the attributes.
-        """
+
+        Example:
+            Example usage of `either_or` logic to filter attributes
+
+            .. highlight:: python
+            .. code-block:: python
+
+                attributes_tree_operand.either_or(
+                    lambda attributes: attributes.is_int(),  # Query for integer attributes
+                    lambda attributes: attributes.is_float(),  # Query for float attributes
+                )
+
+        """  # noqa: W505
         self._attributes_tree_operand.either_or(
             lambda attributes: either(
                 AttributesTreeOperand._from_py_attributes_tree_operand(attributes)
@@ -2057,21 +2074,23 @@ class MultipleAttributesOperand:
         This method evaluates two queries on the multiple attributes and returns all
         attribute names that satisfy either the first query or the second query.
 
-        Example:
-            ```python
-            # Example usage of either_or logic to filter attributes
-            multiple_attributes_operand.either_or(
-                lambda attributes: attributes.is_int(),  # Query for integer attributes
-                lambda attributes: attributes.is_float(),  # Query for float attributes
-            )
-            ```
-
         Args:
             either (Callable[[MultipleAttributesOperand], None]): A query function to
                 evaluate one condition on the multiple attributes.
             or_ (Callable[[MultipleAttributesOperand], None]): A query function to
                 evaluate the alternative condition on the multiple attributes.
-        """
+
+        Example:
+            Example usage of `either_or` logic to filter attributes
+
+            .. highlight:: python
+            .. code-block:: python
+
+                multiple_attributes_operand.either_or(
+                    lambda attributes: attributes.is_int(),  # Query for integer attributes
+                    lambda attributes: attributes.is_float(),  # Query for float attributes
+                )
+        """  # noqa: W505
         self._multiple_attributes_operand.either_or(
             lambda attributes: either(
                 MultipleAttributesOperand._from_py_multiple_attributes_operand(
@@ -2395,18 +2414,19 @@ class SingleAttributeOperand:
         This method evaluates two queries on the single attribute name and returns the
         attribute name that satisfies either the first query or the second query.
 
-        Example:
-        ```python
-        single_attribute_operand.either_or(
-            lambda attribute: attribute.is_in(["a", "b"]),
-            lambda attribute: attribute.is_in(["A", "B"]),
-        )
-        ```
-
         Args:
             either (Callable[[SingleAttributeOperand], None]): One of the queries to
                 apply.
             or_ (Callable[[SingleAttributeOperand], None]): The other query to apply.
+
+        Example:
+            .. highlight:: python
+            .. code-block:: python
+
+                single_attribute_operand.either_or(
+                    lambda attribute: attribute.is_in(["a", "b"]),
+                    lambda attribute: attribute.is_in(["A", "B"]),
+                )
         """
         self._single_attribute_operand.either_or(
             lambda attribute: either(
@@ -2737,16 +2757,18 @@ class NodeIndicesOperand:
         This method evaluates two queries on the node indices and returns all node
         indices that satisfy either the first query or the second query.
 
-        Example:
-        ```python
-        node_indices_operand.either_or(
-            lambda node_indices: node_indices.is_int(),
-            lambda node_indices: node_indices.is_float(),
-        )
-        ```
         Args:
             either (Callable[[NodeIndicesOperand], None]): One of the queries to apply.
             or_ (Callable[[NodeIndicesOperand], None]): The other query to apply.
+
+        Example:
+            .. highlight:: python
+            .. code-block:: python
+
+                node_indices_operand.either_or(
+                    lambda node_indices: node_indices.is_int(),
+                    lambda node_indices: node_indices.is_float(),
+                )
         """
         self._node_indices_operand.either_or(
             lambda node_indices: either(
@@ -3016,16 +3038,17 @@ class NodeIndexOperand:
         This method evaluates two queries on the node index and returns the node index
         that satisfies either the first query or the second query.
 
-        Example:
-        ```python
-        node_index_operand.either_or(
-            lambda index: index.is_int(), lambda index: index.is_float()
-        )
-        ```
-
         Args:
             either (Callable[[NodeIndexOperand], None]): One of the queries to apply.
             or_ (Callable[[NodeIndexOperand], None]): The other query to apply.
+
+        Example:
+            .. highlight:: python
+            .. code-block:: python
+
+                node_index_operand.either_or(
+                    lambda index: index.is_int(), lambda index: index.is_float()
+                )
         """
         self._node_index_operand.either_or(
             lambda node_index: either(
@@ -3311,17 +3334,19 @@ class EdgeIndicesOperand:
         This method evaluates two queries on the edge indices and returns the edge
         indices that satisfy either the first query or the second query.
 
-        Example:
-        ```python
-
-        edge_indices_operand.either_or(
-            lambda edge_indices: edge_indices.contains(1),
-            lambda edge_indices: edge_indices.less_than(10),
-        )
-
         Args:
             either (Callable[[EdgeIndexOperand], None]): One of the queries to apply.
             or_ (Callable[[EdgeIndexOperand], None]): The other query to apply.
+
+        Example:
+            .. highlight:: python
+            .. code-block:: python
+
+                edge_indices_operand.either_or(
+                    lambda edge_indices: edge_indices.contains(1),
+                    lambda edge_indices: edge_indices.less_than(10),
+                )
+
         """
         self._edge_indices_operand.either_or(
             lambda edge_indices: either(
@@ -3549,17 +3574,18 @@ class EdgeIndexOperand:
         This method evaluates two queries on the edge index and returns the edge index
         that satisfies either the first query or the second query.
 
-        Example:
-        ```python
-        edge_index_operand.either_or(
-            lambda edge_index: edge_index.contains(1),
-            lambda edge_index: edge_index.less_than(10),
-        )
-        ```
-
         Args:
             either (Callable[[EdgeIndexOperand], None]): One of the queries to apply.
             or_ (Callable[[EdgeIndexOperand], None]): The other query to apply.
+
+        Example:
+            .. highlight:: python
+            .. code-block:: python
+
+                edge_index_operand.either_or(
+                    lambda edge_index: edge_index.contains(1),
+                    lambda edge_index: edge_index.less_than(10),
+                )
         """
         self._edge_index_operand.either_or(
             lambda edge_index: either(

--- a/medmodels/treatment_effect/estimate.py
+++ b/medmodels/treatment_effect/estimate.py
@@ -71,13 +71,15 @@ class ContingencyTable:
         (false).
 
         Example:
-        -----------------------------------
-                           Outcome
-        Group           True     False
-        -----------------------------------
-        Treated         2        1
-        Control         3        3
-        -----------------------------------
+            .. code-block:: text
+
+                -----------------------------------
+                                Outcome
+                Group           True     False
+                -----------------------------------
+                Treated         2        1
+                Control         3        3
+                -----------------------------------
         """
         line = "-" * 35
         upper_header_line = "{:<18} {:<10}".format("", "Outcome")


### PR DESCRIPTION
This branch fixes critical and non-critical bugs in docstrings. 

* fixed wrongly formatted examples
* fixed wrong order of docstring elements 
* fixed wrong line highlights in the developer guide
* updated badges in the docs/index.md file according to current README.md file

Docs can be built again via `make docs`