### PR TITLE
docs: add version switcher

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -156,7 +156,7 @@ html_theme_options = {
         "json_url": "https://www.medmodels.de/docs/switcher.json",
         "version_match": version,
     },
-    "check_switcher": False,
+    "show_version_warning_banner": True,
 }
 
 html_context = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,20 +1,20 @@
 """Sphinx configuration."""
 
+import importlib.metadata
 import sys
 from datetime import date
 from pathlib import Path
 
-from myst_parser import __version__
 from sphinx.application import Sphinx
 
 # Add parent directory to sys.path for autodoc
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Project information
-project = "medmodels"
+project = "MedModels"
 author = "Limebit GmbH"
 copyright = f"{date.today().year}, {author}"
-version = __version__
+version = importlib.metadata.version(project)
 
 # General configuration
 extensions = [
@@ -152,6 +152,11 @@ html_theme_options = {
     ],
     "primary_sidebar_end": ["indices.html"],
     "secondary_sidebar_items": ["page-toc"],
+    "switcher": {
+        "json_url": "https://www.medmodels.de/docs/switcher.json",
+        "version_match": version,
+    },
+    "check_switcher": False,
 }
 
 html_context = {


### PR DESCRIPTION
This branch is adding the version switcher functionality to our docs. Additionally, a red warning banner is shown, when the user is viewing old docs versions. 

When rendering the docs locally, the switch works. However, when selecting a version from the switch, the docs are referring you to the actual deployed version of the current docs - at this point the version switch doesn't work anymore. 

Deployment info: 

* To make this version switcher work with previously deployed versions of the docs, the previous docs need to get rerendered
* As discussed with @JabobKrauskopf, rerendering the docs should be a one time manual task since the changes just affect some minor front-end functionalities and don't change any content