### PR TITLE
docs: allow for errors to be thrown and shown in documentation

### DIFF
--- a/docs/_static/exec_literalinclude.css
+++ b/docs/_static/exec_literalinclude.css
@@ -1,0 +1,21 @@
+div.admonition.error {
+  background-color: #333;
+  border: 1px solid #8B0000;
+  border-radius: 8px;
+  padding: 10px;
+  margin-bottom: 10px;
+  color: #eee;
+}
+
+div.admonition.error p.admonition-title {
+  background-color: #8B0000;
+  color: white;
+  padding: 1px 8px;
+  border-radius: 1px;
+  font-weight: bold;
+  margin-bottom: 5px;
+}
+
+div.admonition.error .admonition-title::after {
+  content: none !important;
+}

--- a/docs/sphinx_extensions.py
+++ b/docs/sphinx_extensions.py
@@ -14,14 +14,6 @@ Example:
     lines: 6-10
     ---
     ```
-
-    ```{exec_error-literalinclude} path/to/your_script_with_error.py
-    ---
-    language: python
-    setup-lines: 1-4
-    lines: 6-10
-    ---
-    ```
 """
 # ruff: noqa: D100, D103
 
@@ -80,6 +72,7 @@ class ExecLiteralInclude(SphinxDirective):
         "lines": lambda x: x,
         "setup-lines": lambda x: x,
         "language": lambda x: x,
+        "expect-error": lambda x: x,
     }
     has_content = False
 
@@ -107,6 +100,7 @@ class ExecLiteralInclude(SphinxDirective):
             return [error]
 
         total_lines = len(code_lines)
+        expected_error = self.options.get("expect-error")
 
         # Extract setup code
         setup_code = ""
@@ -127,6 +121,7 @@ class ExecLiteralInclude(SphinxDirective):
 
         # Prepare code for execution
         main_code_lines = main_code.rstrip().split("\n")
+
         # Remove trailing empty lines
         while main_code_lines and not main_code_lines[-1].strip():
             main_code_lines.pop()
@@ -157,12 +152,21 @@ class ExecLiteralInclude(SphinxDirective):
                             print(repr(result))  # noqa: T201
                     else:
                         exec(last_line, exec_globals)
+
         except (KeyboardInterrupt, SystemExit):
             raise
         except BaseException as e:
-            error_msg = f"Error executing code: {e}"
-            error_node = nodes.error("", nodes.paragraph(text=error_msg))
-            return [code_node, error_node]
+            if expected_error:
+                if e.__class__.__name__ == expected_error:
+                    return [code_node, ErrorMessageNode(f"{e}")]
+                raise
+            raise
+
+        if expected_error:
+            return [
+                code_node,
+                ErrorMessageNode(f"Expected error '{expected_error}' did not occur."),
+            ]
 
         output_text = output_io.getvalue()
 
@@ -200,136 +204,6 @@ class ExecLiteralInclude(SphinxDirective):
         return parselinenos(line_range_str, total_lines)
 
 
-class ExecErrorLiteralInclude(SphinxDirective):
-    """Directive to include, execute, and display code along with error output."""
-
-    required_arguments = 1
-    optional_arguments = 0
-    option_spec: ClassVar[Dict[str, Callable[[str], Any]]] = {  # pyright: ignore[reportIncompatibleVariableOverride]
-        "lines": lambda x: x,
-        "setup-lines": lambda x: x,
-        "language": lambda x: x,
-        "expect-error": lambda x: x,
-    }
-    has_content = False
-
-    def run(self) -> List[nodes.Node]:  # noqa: C901
-        """Process the directive and return nodes to be inserted into the document.
-
-        Returns:
-            List[nodes.Node]: A list of docutils nodes representing the code block
-                and its output.
-
-        Raises:
-            KeyboardInterrupt: If the code raises a KeyboardInterrupt exception.
-            SystemExit: If the code raises a SystemExit exception.
-        """
-        environment = self.state.document.settings.env
-        _, filename = environment.relfn2path(self.arguments[0])
-
-        try:
-            with Path(filename).open("r") as file:
-                code_lines = file.readlines()
-        except FileNotFoundError:
-            error = self.state_machine.reporter.error(
-                f"File not found: {filename}", line=self.lineno
-            )
-            return [error]
-
-        total_lines = len(code_lines)
-
-        setup_code = ""
-        assert all(option in self.options for option in ["lines", "expect-error"])
-
-        if "setup-lines" in self.options:
-            setup_line_numbers = parselinenos(self.options["setup-lines"], total_lines)
-            setup_code = "".join([code_lines[i] for i in setup_line_numbers])
-
-        main_line_numbers = parselinenos(self.options["lines"], total_lines)
-        main_code = "".join([code_lines[i] for i in main_line_numbers])
-
-        expected_error = self.options.get("expect-error")
-
-        code_node = nodes.literal_block(main_code, main_code)
-        code_node["language"] = self.options.get("language", "python")
-
-        main_code_lines = main_code.rstrip().split("\n")
-        while main_code_lines and not main_code_lines[-1].strip():
-            main_code_lines.pop()
-        if main_code_lines:
-            last_line = main_code_lines.pop()
-            code_before_last_line = "\n".join(main_code_lines)
-        else:
-            last_line = ""
-            code_before_last_line = ""
-
-        output_io = io.StringIO()
-        exec_globals = {}
-
-        try:
-            with (
-                contextlib.redirect_stdout(output_io),
-                contextlib.redirect_stderr(output_io),
-            ):
-                if setup_code:
-                    exec(setup_code, exec_globals)
-                if code_before_last_line:
-                    exec(code_before_last_line, exec_globals)
-                if last_line:
-                    if self._is_expression(last_line):
-                        result = eval(last_line, exec_globals)
-                        if result is not None:
-                            print(repr(result))  # noqa: T201
-                    else:
-                        exec(last_line, exec_globals)
-
-            # Place this block here: Check if an error was expected but didn't occur
-            error_msg = (
-                f"Expected an error of type '{expected_error}', but no error occurred."
-            )
-            return [code_node, ErrorMessageNode(error_msg)]
-
-        except (KeyboardInterrupt, SystemExit):
-            raise
-        except BaseException as e:
-            expected_error = self.options.get("expect-error")
-
-            if expected_error:
-                if e.__class__.__name__ == expected_error:
-                    # Expected error occurred, show the traceback
-                    error_msg = f"Expected error occurred: {type(e).__name__} - {e}"
-                    return [code_node, ErrorMessageNode(error_msg)]
-
-                error_msg = (
-                    f"Unexpected error type. Expected '{expected_error}', "
-                    f"but got '{e.__class__.__name__}'."
-                )
-                return [code_node, ErrorMessageNode(error_msg)]
-
-            # No expected error provided, show full traceback
-            error_msg = f"Error executing code: {type(e).__name__} - {e}"
-            return [code_node, ErrorMessageNode(error_msg)]
-
-    def _is_expression(self, code_line: str) -> bool:
-        try:
-            compile(code_line, "<string>", "eval")
-            return True
-        except SyntaxError:
-            return False
-
-    def _parse_line_range(self, line_range_str: str, total_lines: int) -> List[int]:
-        """Parse a line range string into a list of line indices.
-
-        Args:
-            line_range_str (str): The line range string (e.g., "1-3,5").
-            total_lines (int): The total number of lines in the source file.
-
-        Returns:
-            List[int]: A list of line indices (0-based).
-        """
-        return parselinenos(line_range_str, total_lines)
-
-
 def setup(app: Sphinx) -> None:
     """Set up the Sphinx extension.
 
@@ -337,7 +211,6 @@ def setup(app: Sphinx) -> None:
         app (Sphinx): The Sphinx application instance.
     """
     app.add_directive("exec-literalinclude", ExecLiteralInclude)
-    app.add_directive("exec_error-literalinclude", ExecErrorLiteralInclude)
     app.add_node(
         ErrorMessageNode, html=(visit_error_message_node, depart_error_message_node)
     )

--- a/docs/sphinx_extensions.py
+++ b/docs/sphinx_extensions.py
@@ -2,9 +2,9 @@
 
 This module defines two custom Sphinx directives:
 1. `exec-literalinclude` that allows including code from external files,
-   executing it, and displaying both the code and its output.
-2. `exec_error-literalinclude` that executes code and, if an error occurs,
-   prints the full traceback along with the code.
+   executing it, and displaying both the code and its output. In case the user
+   wants to show an expected error message, they can specify the error message
+    using the `expect-error` option.
 
 Example:
     ```{exec-literalinclude} path/to/your_script.py

--- a/docs/sphinx_extensions.py
+++ b/docs/sphinx_extensions.py
@@ -161,10 +161,8 @@ class ExecLiteralInclude(SphinxDirective):
         except (KeyboardInterrupt, SystemExit):
             raise
         except BaseException as e:
-            if expected_error:
-                if e.__class__.__name__ == expected_error:
-                    return [code_node, ErrorMessageNode(f"{expected_error}: {e}")]
-                raise
+            if expected_error and e.__class__.__name__ == expected_error:
+                return [code_node, ErrorMessageNode(f"{expected_error}: {e}")]
             raise
 
         if expected_error:

--- a/docs/sphinx_extensions.py
+++ b/docs/sphinx_extensions.py
@@ -41,23 +41,27 @@ class ErrorMessageNode(nodes.General, nodes.Element):
         self.message = message
 
 
-def visit_error_message_node(self: nodes.NodeVisitor, node: ErrorMessageNode) -> None:
+def visit_error_message_node(
+    visitor: nodes.NodeVisitor, node: ErrorMessageNode
+) -> None:
     """Visitor function to generate HTML for ErrorMessageNode.
 
     Args:
-        self (nodes.NodeVisitor): The visitor instance.
+        visitor (nodes.NodeVisitor): The visitor instance.
         node (ErrorMessageNode): The ErrorMessageNode instance.
     """
-    self.body.append(  # pyright: ignore[reportAttributeAccessIssue]
+    visitor.body.append(  # pyright: ignore[reportAttributeAccessIssue]
         f'<div class="admonition error"><p class="admonition-title error-title">Error:</p><p>{node.message}</p></div>'
     )
 
 
-def depart_error_message_node(self: nodes.NodeVisitor, node: ErrorMessageNode) -> None:
-    """Departure function for ErrorMessageNode.
+def depart_error_message_node(
+    visitor: nodes.NodeVisitor, node: ErrorMessageNode
+) -> None:
+    """Departure function for ErrorMessageNode. Placeholder function.
 
     Args:
-        self (nodes.NodeVisitor): The visitor instance.
+        visitor (nodes.NodeVisitor): The visitor instance.
         node (ErrorMessageNode): The ErrorMessageNode instance.
     """
     pass
@@ -86,6 +90,7 @@ class ExecLiteralInclude(SphinxDirective):
         Raises:
             KeyboardInterrupt: If the code raises a KeyboardInterrupt exception.
             SystemExit: If the code raises a SystemExit exception.
+            RuntimeError: If an expected error does not occur.
         """
         environment = self.state.document.settings.env
         _, filename = environment.relfn2path(self.arguments[0])
@@ -158,15 +163,13 @@ class ExecLiteralInclude(SphinxDirective):
         except BaseException as e:
             if expected_error:
                 if e.__class__.__name__ == expected_error:
-                    return [code_node, ErrorMessageNode(f"{e}")]
+                    return [code_node, ErrorMessageNode(f"{expected_error}: {e}")]
                 raise
             raise
 
         if expected_error:
-            return [
-                code_node,
-                ErrorMessageNode(f"Expected error '{expected_error}' did not occur."),
-            ]
+            msg = f"Expected error '{expected_error}' did not occur."
+            raise RuntimeError(msg)
 
         output_text = output_io.getvalue()
 

--- a/docs/sphinx_extensions.py
+++ b/docs/sphinx_extensions.py
@@ -1,10 +1,9 @@
 """Sphinx extension to execute included code snippets and display their output.
 
-This module defines two custom Sphinx directives:
-1. `exec-literalinclude` that allows including code from external files,
-   executing it, and displaying both the code and its output. In case the user
-   wants to show an expected error message, they can specify the error message
-    using the `expect-error` option.
+This module defines a custom Sphinx directive `ExecLiteralInclude` that allows
+including code from external files, executing it, and displaying both the code
+and its output in the documentation. In case the user wants to show an expected error
+message, they can specify the error message using the `expect-error` option.
 
 Example:
     ```{exec-literalinclude} path/to/your_script.py
@@ -12,6 +11,7 @@ Example:
     language: python
     setup-lines: 1-4
     lines: 6-10
+    expect-error: ValueError
     ---
     ```
 """

--- a/docs/user_guide/02b_query_engine.md
+++ b/docs/user_guide/02b_query_engine.md
@@ -48,8 +48,8 @@ The [`NodeOperand`](medmodels.medrecord.querying.NodeOperand){target="_blank"} q
 ```{exec-literalinclude} scripts/02b_query_engine.py
 ---
 language: python
-setup-lines: 1-5
-lines: 9-13
+setup-lines: 1-6
+lines: 10-14
 ---
 ```
 
@@ -65,8 +65,8 @@ You can get to the same result via different approaches. That makes the query en
 ```{exec-literalinclude} scripts/02b_query_engine.py
 ---
 language: python
-setup-lines: 1-5
-lines: 17-25
+setup-lines: 1-6
+lines: 18-26
 ---
 ```
 
@@ -93,8 +93,8 @@ As you can see, the query engine can prove to be highly useful for finding nodes
 ```{exec-literalinclude} scripts/02b_query_engine.py
 ---
 language: python
-setup-lines: 1-13
-lines: 29-37
+setup-lines: 1-14
+lines: 30-38
 ---
 ```
 
@@ -124,8 +124,8 @@ You can also perform mathematical calculations like [`mean()`](medmodels.medreco
 ```{exec-literalinclude} scripts/02b_query_engine.py
 ---
 language: python
-setup-lines: 1-5
-lines: 41-56
+setup-lines: 1-6
+lines: 42-57
 ---
 ```
 
@@ -149,42 +149,34 @@ lines: 41-56
 :::
 
 :::{note}
-Query methods used for changing the operands cannot be concatenated or assigned to variables, since their Return is None. That is, the following code snippet will set `gender_lowercase` as None, and as a result, an AttributeError will be thrown:
+Query methods used for changing the operands cannot be assigned to variables, for further querying, since their _Return_ is `None`. That is, the following code snippet will set `gender_lowercase` as None, and as a result, an `AttributeError` will be thrown:
 
-```python
-# Wrong implementation
-gender_lowercase = node.attribute("gender").lowercase()
-gender_lowercase.equal_to("m")
-
-AttributeError("'NoneType' object has no attribute 'equal_to'")
-
-# Wrong implementation
-gender = node.attribute("gender")
-gender.lowercase().trim()
-gender.equal_to("m")
-
-AttributeError("'NoneType' object has no attribute 'trim'")
-
-# Correct implementation
-gender = node.attribute("gender")
-gender.lowercase()
-gender.trim()
-gender.equal_to("m")
+```{exec_error-literalinclude} scripts/02b_query_engine.py
+---
+language: python
+setup-lines: 1-6
+lines: 61-68
+---
 ```
 
-Nor do the ones that compare operands to other operands, since their Return value is also None.
+Nor does the concatenation of querying methods:
 
-```python
-# Wrong implementation
-gender = node.attribute("gender")
-gender.equal_to("M").not_equal_to("F")
+```{exec_error-literalinclude} scripts/02b_query_engine.py
+---
+language: python
+setup-lines: 1-6
+lines: 72-78
+---
+```
 
-AttributeError("'NoneType' object has no attribute 'not_equal_to'")
+**Correct implementation**:
 
-# Correct implementation
-gender = node.attribute("gender")
-gender.equal_to("M")
-gender.not_equal_to("F")
+```{exec-literalinclude} scripts/02b_query_engine.py
+---
+language: python
+setup-lines: 1-6
+lines: 82-89
+---
 ```
 
 :::
@@ -201,8 +193,8 @@ In this following example we are selecting the nodes that fulfill the following 
 ```{exec-literalinclude} scripts/02b_query_engine.py
 ---
 language: python
-setup-lines: 1-5, 16-25
-lines: 60-68
+setup-lines: 1-6, 17-26
+lines: 93-101
 ---
 ```
 
@@ -223,8 +215,8 @@ The querying class [`EdgeOperand`](medmodels.medrecord.querying.EdgeOperand){tar
 ```{exec-literalinclude} scripts/02b_query_engine.py
 ---
 language: python
-setup-lines: 1-5
-lines: 72-77
+setup-lines: 1-6
+lines: 105-110
 ---
 ```
 
@@ -240,8 +232,8 @@ The edge operand follows the same principles as the node operand, with some extr
 ```{exec-literalinclude} scripts/02b_query_engine.py
 ---
 language: python
-setup-lines: 1-5
-lines: 81-89
+setup-lines: 1-6
+lines: 114-122
 ---
 ```
 
@@ -269,8 +261,8 @@ The full power of the query engine appears once you combine both operands inside
 ```{exec-literalinclude} scripts/02b_query_engine.py
 ---
 language: python
-setup-lines: 1-5
-lines: 93-108
+setup-lines: 1-6
+lines: 126-141
 ---
 ```
 
@@ -294,8 +286,8 @@ The inherent structure of the query engine works with logical **AND** operations
 ```{exec-literalinclude} scripts/02b_query_engine.py
 ---
 language: python
-setup-lines: 1-5
-lines: 112-131
+setup-lines: 1-6
+lines: 145-164
 ---
 ```
 
@@ -317,8 +309,8 @@ This includes also _"pat_3"_, that was not included in the previous section beca
 ```{exec-literalinclude} scripts/02b_query_engine.py
 ---
 language: python
-setup-lines: 1-5, 110-130
-lines: 135-140
+setup-lines: 1-6, 143-163
+lines: 168-173
 ---
 ```
 
@@ -341,8 +333,8 @@ To address this limitation, the [`clone()`](medmodels.medrecord.querying.SingleV
 ```{exec-literalinclude} scripts/02b_query_engine.py
 ---
 language: python
-setup-lines: 1-5
-lines: 144-158
+setup-lines: 1-6
+lines: 177-191
 ---
 ```
 
@@ -370,8 +362,8 @@ In all previous snippets, we have used queries with the method [`select_nodes()`
 ```{exec-literalinclude} scripts/02b_query_engine.py
 ---
 language: python
-setup-lines: 1-154
-lines: 161
+setup-lines: 1-6, 145-187
+lines: 194
 ---
 ```
 
@@ -380,8 +372,8 @@ lines: 161
 ```{exec-literalinclude} scripts/02b_query_engine.py
 ---
 language: python
-setup-lines: 1-154
-lines: 162
+setup-lines: 1-23
+lines: 195
 ---
 ```
 
@@ -390,8 +382,8 @@ lines: 162
 ```{exec-literalinclude} scripts/02b_query_engine.py
 ---
 language: python
-setup-lines: 1-155
-lines: 163
+setup-lines: 1-6, 114-119
+lines: 196
 ---
 ```
 
@@ -410,6 +402,6 @@ The full code examples for this chapter can be found here:
 ```{literalinclude} scripts/02b_query_engine.py
 ---
 language: python
-lines: 2-163
+lines: 3-196
 ---
 ```

--- a/docs/user_guide/02b_query_engine.md
+++ b/docs/user_guide/02b_query_engine.md
@@ -151,7 +151,7 @@ lines: 42-57
 :::{note}
 Query methods used for changing the operands cannot be assigned to variables, for further querying, since their _Return_ is `None`. That is, the following code snippet will set `gender_lowercase` as None, and as a result, an `AttributeError` will be thrown:
 
-```{exec_error-literalinclude} scripts/02b_query_engine.py
+```{exec-literalinclude} scripts/02b_query_engine.py
 ---
 language: python
 setup-lines: 1-6
@@ -162,7 +162,7 @@ expect-error: PanicException
 
 Nor does the concatenation of querying methods:
 
-```{exec_error-literalinclude} scripts/02b_query_engine.py
+```{exec-literalinclude} scripts/02b_query_engine.py
 ---
 language: python
 setup-lines: 1-6

--- a/docs/user_guide/02b_query_engine.md
+++ b/docs/user_guide/02b_query_engine.md
@@ -149,7 +149,7 @@ lines: 42-57
 :::
 
 :::{note}
-Query methods used for changing the operands cannot be assigned to variables for further querying, since their return type is `None`. That can be appreciated in the following code snippet, where the variable `gender_lowercase` in the query takes None as value. An `AttributeError` is thrown as a consequence when trying to further query with the `equal_to` querying method:
+Query methods used for changing the operands cannot be assigned to variables for further querying, since their return type is `None`. The following code snippet shows an example, where the variable `gender_lowercase` evaluates to None. An `AttributeError` is thrown as a consequence when trying to further query with the `equal_to` querying method:
 
 ```{exec-literalinclude} scripts/02b_query_engine.py
 ---

--- a/docs/user_guide/02b_query_engine.md
+++ b/docs/user_guide/02b_query_engine.md
@@ -149,7 +149,7 @@ lines: 42-57
 :::
 
 :::{note}
-Query methods used for changing the operands cannot be assigned to variables, for further querying, since their _Return_ is `None`. That is, the following code snippet will set `gender_lowercase` as None, and as a result, an `AttributeError` will be thrown:
+Query methods used for changing the operands cannot be assigned to variables for further querying, since their return type is `None`. That can be appreciated in the following code snippet, where the variable `gender_lowercase` in the query takes None as value. An `AttributeError` is thrown as a consequence when trying to further query with the `equal_to` querying method:
 
 ```{exec-literalinclude} scripts/02b_query_engine.py
 ---

--- a/docs/user_guide/02b_query_engine.md
+++ b/docs/user_guide/02b_query_engine.md
@@ -156,6 +156,7 @@ Query methods used for changing the operands cannot be assigned to variables, fo
 language: python
 setup-lines: 1-6
 lines: 61-68
+expect-error: PanicException
 ---
 ```
 
@@ -166,6 +167,7 @@ Nor does the concatenation of querying methods:
 language: python
 setup-lines: 1-6
 lines: 72-78
+expect-error: PanicException
 ---
 ```
 

--- a/docs/user_guide/scripts/02b_query_engine.py
+++ b/docs/user_guide/scripts/02b_query_engine.py
@@ -1,3 +1,4 @@
+# pyright: reportAttributeAccessIssue=false
 # ruff: noqa: D100, D103
 from medmodels import MedRecord
 from medmodels.medrecord.querying import EdgeOperand, NodeOperand
@@ -54,6 +55,38 @@ def query_node_male_patient_under_mean(node: NodeOperand) -> None:
 
 
 medrecord.select_nodes(query_node_male_patient_under_mean)
+
+
+# Incorrect implementation because the querying methods are assigned to a variable
+def query_operand_assigned(node: NodeOperand) -> None:
+    gender_lowercase = node.attribute(
+        "gender"
+    ).lowercase()  # Assigning the querying method to a variable
+    gender_lowercase.equal_to("m")
+
+
+medrecord.select_nodes(query_operand_assigned)
+
+
+# Incorrect implementation because the querying methods are concatenated
+def query_operands_concatenated(node: NodeOperand) -> None:
+    gender = node.attribute("gender")
+    gender.lowercase().trim()  # Concatenating the querying methods
+    gender.equal_to("m")
+
+
+medrecord.select_nodes(query_operands_concatenated)
+
+
+# Correct implementation
+def query_correct_implementation(node: NodeOperand) -> None:
+    gender = node.attribute("gender")
+    gender.lowercase()
+    gender.trim()
+    gender.equal_to("m")
+
+
+medrecord.select_nodes(query_correct_implementation)
 
 
 # Node query with neighbors function


### PR DESCRIPTION
# Medmodels Pull Request

## Description

Adding an `Sphinx` extension that allows for showing errors when they are intended. Closes Issue #321 .

## Checklist

- [X] This Pull Request follows the rules established in the [Developer Guide](https://www.medmodels.de/docs/latest/developer_guide/pull-request.html).
