### PR TITLE
build: add scipy and scipy-stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pandas>=2.2.2",
     "polars[pandas]>=1.6.0",
     "scikit-learn>=1.5.0",
-    "scipy>=1.15.1",
+    "scipy>=1.6.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "pandas>=2.2.2",
     "polars[pandas]>=1.6.0",
     "scikit-learn>=1.5.0",
+    "scipy-stubs>=1.6.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pandas>=2.2.2",
     "polars[pandas]>=1.6.0",
     "scikit-learn>=1.5.0",
-    "scipy-stubs>=1.6.0",
+    "scipy>=1.15.1",
 ]
 
 [project.optional-dependencies]
@@ -65,6 +65,7 @@ dev = [
     "py-spy",
     "pyright>=1.1.370,<1.1.374",
     "pandas-stubs>=2.2.2.240603",
+    "scipy-stubs>=1.15.1.0",
 ]
 
 [build-system]


### PR DESCRIPTION
# Medmodels Pull Request

## Description

Adding `scipy-stubs` as dependency to be able to lint `scipy` inputs/outputs correctly.

## Checklist

- [X] This Pull Request follows the rules established in the [Developer Guide](https://www.medmodels.de/docs/latest/developer_guide/pull-request.html).
