### PR TITLE
fix: polars version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dependencies = [
     "numpy>=2.0.0",
     "pandas>=2.2.2",
-    "polars[pandas]<=1.17.0",
+    "polars[pandas]>=1.6.0",
     "scikit-learn>=1.5.0",
 ]
 


### PR DESCRIPTION
# Medmodels Pull Request

## Description

The last PR to update the polars version #308 was actually incorrect for two reasons:
1. The issue did not include that we should switch back to the old version instead
2. The issue incorrectly states that the version should be `<=` instead of the correct `>=`

## Checklist

- [x] This Pull Request follows the rules established in the [Developer Guide](https://www.medmodels.de/docs/latest/developer_guide/pull-request.html).
