### PR TITLE
refactor: changing overview functions so that they take node/edges + groups as input.

### DIFF
--- a/medmodels/medrecord/medrecord.py
+++ b/medmodels/medrecord/medrecord.py
@@ -1344,10 +1344,13 @@ class MedRecord:
         """
         nodes_info = {}
         grouped_nodes = []
+
         add_ungrouped = False
+        return_empty = False
 
         if not nodes:
             nodes = self.nodes
+            return_empty = True
 
         if not groups:
             add_ungrouped = True
@@ -1360,7 +1363,9 @@ class MedRecord:
             nodes_in_group = list(set(all_nodes_in_group).intersection(set(nodes)))
             grouped_nodes.extend(nodes_in_group)
 
-            if (len(nodes_in_group) == 0) and (self.group(group)["edges"]):
+            if (len(nodes_in_group) == 0) and (
+                (self.group(group)["edges"]) or not return_empty
+            ):
                 continue
 
             schema = self.get_schema()
@@ -1466,8 +1471,8 @@ class MedRecord:
     def overview_nodes(
         self,
         *,
-        node: Optional[Union[NodeIndex, NodeIndexInputList, NodeQuery]] = None,
-        group: Optional[Union[Group, GroupInputList]] = None,
+        nodes: Optional[Union[NodeIndex, NodeIndexInputList, NodeQuery]] = None,
+        groups: Optional[Union[Group, GroupInputList]] = None,
         decimal: int = 2,
     ) -> OverviewTable:
         """Gets a summary of the specified node(s) in the specified group(s).
@@ -1479,20 +1484,22 @@ class MedRecord:
             specified groups.
         - In case both nodes and groups are provided, the method returns a summary of
             the nodes in the specified groups.
+        - In case no nodes or groups are provided, the method returns a summary of all
+            nodes in the MedRecord and all groups which contain nodes or are empty.
 
         Args:
-            node (Optional[Union[NodeIndex, NodeIndexInputList, NodeQuery]], optional):
+            nodes (Optional[Union[NodeIndex, NodeIndexInputList, NodeQuery]], optional):
                 One or more node indices or a node query to get an overview of.
                 If no nodes are given, all nodes in the MedRecord are used. Defaults
                 to None.
-            group (Optional[Union[Group, GroupInputList]], optional): Group or list of
+            groups (Optional[Union[Group, GroupInputList]], optional): Group or list of
                 groups to display. If no groups are given, all groups containing the
                 specified nodes are shown. Defaults to None.
             decimal (int, optional): Decimal point to round the float values to.
                 Defaults to 2.
 
         Returns:
-            OverviewTable: Display of edge groups and their attributes.
+            OverviewTable: Display of node groups and their attributes.
 
         Example:
             .. code-block:: text
@@ -1508,15 +1515,15 @@ class MedRecord:
                 Ungrouped Nodes 10    -           -           -
                 --------------------------------------------------------------
         """
-        if isinstance(group, Group):
-            group = [group]
+        if isinstance(groups, Group):
+            groups = [groups]
 
-        if isinstance(node, NodeIndex):
-            node = [node]
-        elif isinstance(node, Callable):
-            node = self.select_nodes(node)
+        if isinstance(nodes, NodeIndex):
+            nodes = [nodes]
+        elif isinstance(nodes, Callable):
+            nodes = self.select_nodes(nodes)
 
-        nodes_data = self._describe_group_nodes(nodes=node, groups=group)
+        nodes_data = self._describe_group_nodes(nodes=nodes, groups=groups)
 
         return OverviewTable(
             data=nodes_data, group_header="Nodes Group", decimal=decimal
@@ -1525,8 +1532,8 @@ class MedRecord:
     def overview_edges(
         self,
         *,
-        edge: Optional[Union[EdgeIndex, EdgeIndexInputList, EdgeQuery]] = None,
-        group: Optional[Union[Group, GroupInputList]] = None,
+        edges: Optional[Union[EdgeIndex, EdgeIndexInputList, EdgeQuery]] = None,
+        groups: Optional[Union[Group, GroupInputList]] = None,
         decimal: int = 2,
     ) -> OverviewTable:
         """Gets a summary of the specified edge(s) in the specified group(s).
@@ -1538,13 +1545,15 @@ class MedRecord:
             specified groups.
         - In case both edges and groups are provided, the method returns a summary of
             the edges in the specified groups.
+        - In case no edges or groups are provided, the method returns a summary of all
+            edges in the MedRecord and all groups which contain edges.
 
         Args:
-            edge (Optional[Union[EdgeIndex, EdgeIndexInputList, EdgeQuery]], optional):
+            edges (Optional[Union[EdgeIndex, EdgeIndexInputList, EdgeQuery]], optional):
                 One or more edge indices or an edge query to get an overview of.
                 If no edges are given, all edges in the MedRecord are used. Defaults
                 to None
-            group (Optional[Union[Group, GroupInputList]], optional): Group or list of
+            groups (Optional[Union[Group, GroupInputList]], optional): Group or list of
                 edge groups to display. If no groups are given, all groups containing
                 nodes are shown. Defaults to None.
             decimal (int, optional): Decimal point to round the float values to.
@@ -1567,15 +1576,15 @@ class MedRecord:
                 --------------------------------------------------------------------------
 
         """  # noqa: W505
-        if isinstance(group, Group):
-            group = [group]
+        if isinstance(groups, Group):
+            groups = [groups]
 
-        if isinstance(edge, EdgeIndex):
-            edge = [edge]
-        elif isinstance(edge, Callable):
-            edge = self.select_edges(edge)
+        if isinstance(edges, EdgeIndex):
+            edges = [edges]
+        elif isinstance(edges, Callable):
+            edges = self.select_edges(edges)
 
-        edges_data = self._describe_group_edges(edges=edge, groups=group)
+        edges_data = self._describe_group_edges(edges=edges, groups=groups)
 
         return OverviewTable(
             data=edges_data, group_header="Edges Group", decimal=decimal

--- a/medmodels/medrecord/medrecord.py
+++ b/medmodels/medrecord/medrecord.py
@@ -1345,12 +1345,12 @@ class MedRecord:
         nodes_info = {}
         grouped_nodes = []
 
-        set_nodes = self.nodes if not nodes else set(nodes)
+        nodes_set = self.nodes if not nodes else set(nodes)
         groups_sorted = sorted(groups or self.groups, key=lambda x: str(x))
 
         for group in groups_sorted:
             all_nodes_in_group = self.group(group)["nodes"]
-            nodes_in_group = list(set(all_nodes_in_group).intersection(set_nodes))
+            nodes_in_group = list(set(all_nodes_in_group).intersection(nodes_set))
             grouped_nodes.extend(nodes_in_group)
 
             if (len(nodes_in_group) == 0) and (
@@ -1374,8 +1374,7 @@ class MedRecord:
         if groups:
             return nodes_info
 
-        # If no groups were specified, add ungrouped nodes
-        ungrouped_count = len(set_nodes) - len(set(grouped_nodes))
+        ungrouped_count = len(nodes_set) - len(set(grouped_nodes))
 
         if ungrouped_count > 0:
             nodes_info["Ungrouped Nodes"] = {
@@ -1407,12 +1406,12 @@ class MedRecord:
         edges_info = {}
         grouped_edges = []
 
+        edges_set = set(edges or self.edges)
         groups_sorted = sorted(groups or self.groups, key=lambda x: str(x))
-        set_edges = set(edges or self.edges)
 
         for group in groups_sorted:
             all_edges_in_group = self.group(group)["edges"]
-            edges_in_group = list(set(all_edges_in_group).intersection(set_edges))
+            edges_in_group = list(set(all_edges_in_group).intersection(edges_set))
             grouped_edges.extend(edges_in_group)
 
             if not edges_in_group:
@@ -1434,7 +1433,7 @@ class MedRecord:
         if groups:
             return edges_info
 
-        ungrouped_count = len(set_edges) - len(set(grouped_edges))
+        ungrouped_count = len(edges_set) - len(set(grouped_edges))
 
         if ungrouped_count > 0:
             edges_info["Ungrouped Edges"] = {

--- a/medmodels/medrecord/medrecord.py
+++ b/medmodels/medrecord/medrecord.py
@@ -1345,26 +1345,16 @@ class MedRecord:
         nodes_info = {}
         grouped_nodes = []
 
-        add_ungrouped = False
-        return_empty = False
+        set_nodes = self.nodes if not nodes else set(nodes)
+        groups_sorted = sorted(groups or self.groups, key=lambda x: str(x))
 
-        if not nodes:
-            nodes = self.nodes
-            return_empty = True
-
-        if not groups:
-            add_ungrouped = True
-            groups = self.groups
-
-        groups = sorted(groups, key=lambda x: str(x))
-
-        for group in groups:
+        for group in groups_sorted:
             all_nodes_in_group = self.group(group)["nodes"]
-            nodes_in_group = list(set(all_nodes_in_group).intersection(set(nodes)))
+            nodes_in_group = list(set(all_nodes_in_group).intersection(set_nodes))
             grouped_nodes.extend(nodes_in_group)
 
             if (len(nodes_in_group) == 0) and (
-                (self.group(group)["edges"]) or not return_empty
+                (self.group(group)["edges"]) or nodes is not None
             ):
                 continue
 
@@ -1381,10 +1371,11 @@ class MedRecord:
                 ),
             }
 
-        if not add_ungrouped:
+        if groups:
             return nodes_info
 
-        ungrouped_count = len(nodes) - len(set(grouped_nodes))
+        # If no groups were specified, add ungrouped nodes
+        ungrouped_count = len(set_nodes) - len(set(grouped_nodes))
 
         if ungrouped_count > 0:
             nodes_info["Ungrouped Nodes"] = {
@@ -1415,20 +1406,13 @@ class MedRecord:
         """
         edges_info = {}
         grouped_edges = []
-        add_ungrouped = False
 
-        if not edges:
-            edges = self.edges
+        groups_sorted = sorted(groups or self.groups, key=lambda x: str(x))
+        set_edges = set(edges or self.edges)
 
-        if not groups:
-            add_ungrouped = True
-            groups = self.groups
-
-        groups = sorted(groups, key=lambda x: str(x))
-
-        for group in groups:
+        for group in groups_sorted:
             all_edges_in_group = self.group(group)["edges"]
-            edges_in_group = list(set(all_edges_in_group).intersection(set(edges)))
+            edges_in_group = list(set(all_edges_in_group).intersection(set_edges))
             grouped_edges.extend(edges_in_group)
 
             if not edges_in_group:
@@ -1447,10 +1431,10 @@ class MedRecord:
                 ),
             }
 
-        if not add_ungrouped:
+        if groups:
             return edges_info
 
-        ungrouped_count = len(edges) - len(set(grouped_edges))
+        ungrouped_count = len(set_edges) - len(set(grouped_edges))
 
         if ungrouped_count > 0:
             edges_info["Ungrouped Edges"] = {
@@ -1520,6 +1504,7 @@ class MedRecord:
 
         if isinstance(nodes, NodeIndex):
             nodes = [nodes]
+
         elif isinstance(nodes, Callable):
             nodes = self.select_nodes(nodes)
 
@@ -1581,6 +1566,7 @@ class MedRecord:
 
         if isinstance(edges, EdgeIndex):
             edges = [edges]
+
         elif isinstance(edges, Callable):
             edges = self.select_edges(edges)
 

--- a/medmodels/medrecord/tests/test_medrecord.py
+++ b/medmodels/medrecord/tests/test_medrecord.py
@@ -1888,6 +1888,22 @@ class TestMedRecord(unittest.TestCase):
             },
         }
 
+        # test node input list
+        assert medrecord._describe_group_nodes(nodes=["0", "1"]) == {
+            1: {
+                "count": 1,
+                "attribute": {
+                    "dolor": {"type": "Categorical", "values": "Categories: sit"},
+                    "lorem": {"type": "Categorical", "values": "Categories: ipsum"},
+                },
+            },
+            "Float": {"count": 0, "attribute": {}},
+            "Ungrouped Nodes": {
+                "count": 1,
+                "attribute": {},
+            },
+        }
+
         # test group input list
         medrecord.add_group("Odd", nodes=["1", "3"])
 
@@ -1895,6 +1911,16 @@ class TestMedRecord(unittest.TestCase):
             "Float": {"count": 0, "attribute": {}},
             "Odd": {
                 "count": 2,
+                "attribute": {
+                    "amet": {"type": "Categorical", "values": "Categories: consectetur"}
+                },
+            },
+        }
+
+        # test both node and group input list
+        assert medrecord._describe_group_nodes(nodes=["0", "1"], groups=["Odd"]) == {
+            "Odd": {
+                "count": 1,
                 "attribute": {
                     "amet": {"type": "Categorical", "values": "Categories: consectetur"}
                 },
@@ -1918,6 +1944,18 @@ class TestMedRecord(unittest.TestCase):
             "Ungrouped Edges": {"count": 2, "attribute": {}},
         }
 
+        # test edge input list
+        assert medrecord._describe_group_edges(edges=[0, 1]) == {
+            "Even": {
+                "count": 1,
+                "attribute": {
+                    "eiusmod": {"type": "Categorical", "values": "Categories: tempor"},
+                    "sed": {"type": "Categorical", "values": "Categories: do"},
+                },
+            },
+            "Ungrouped Edges": {"count": 1, "attribute": {}},
+        }
+
         # test the specified group list
         assert medrecord._describe_group_edges(groups=["Even"]) == {
             "Even": {
@@ -1925,6 +1963,17 @@ class TestMedRecord(unittest.TestCase):
                 "attribute": {
                     "eiusmod": {"type": "Categorical", "values": "Categories: tempor"},
                     "incididunt": {"type": "Categorical", "values": "Categories: ut"},
+                    "sed": {"type": "Categorical", "values": "Categories: do"},
+                },
+            },
+        }
+
+        # test both edge and group input list
+        assert medrecord._describe_group_edges(edges=[0, 1], groups=["Even"]) == {
+            "Even": {
+                "count": 1,
+                "attribute": {
+                    "eiusmod": {"type": "Categorical", "values": "Categories: tempor"},
                     "sed": {"type": "Categorical", "values": "Categories: do"},
                 },
             },
@@ -1945,7 +1994,7 @@ class TestMedRecord(unittest.TestCase):
                 "                                                 max: 2024-04-12 00:00:00 ",
                 "--------------------------------------------------------------------------",
             ]
-        ) == str(medrecord.overview_edges("patient_diagnosis"))
+        ) == str(medrecord.overview_edges(group="patient_diagnosis"))
 
 
 if __name__ == "__main__":

--- a/medmodels/medrecord/tests/test_medrecord.py
+++ b/medmodels/medrecord/tests/test_medrecord.py
@@ -1978,8 +1978,95 @@ class TestMedRecord(unittest.TestCase):
             },
         }
 
+    def test_overview_nodes(self) -> None:
+        medrecord = MedRecord.from_simple_example_dataset()
+
+        assert "\n".join(
+            [
+                "------------------------------------------------------",
+                "Nodes Group Count Attribute Type        Data          ",
+                "------------------------------------------------------",
+                "patient     1     age       Continuous  min: 42       ",
+                "                                        max: 42       ",
+                "                                        mean: 42.00   ",
+                "                  gender    Categorical Categories: M ",
+                "------------------------------------------------------",
+            ]
+        ) == str(medrecord.overview_nodes(nodes="pat_1"))
+
+        def query(node: NodeOperand) -> None:
+            node.has_attribute("age")
+
+        assert "\n".join(
+            [
+                "---------------------------------------------------------",
+                "Nodes Group Count Attribute Type        Data             ",
+                "---------------------------------------------------------",
+                "patient     5     age       Continuous  min: 19          ",
+                "                                        max: 96          ",
+                "                                        mean: 43.20      ",
+                "                  gender    Categorical Categories: F, M ",
+                "---------------------------------------------------------",
+            ]
+        ) == str(medrecord.overview_nodes(nodes=query))
+
+        assert "\n".join(
+            [
+                "---------------------------------------------------------",
+                "Nodes Group Count Attribute Type        Data             ",
+                "---------------------------------------------------------",
+                "patient     5     age       Continuous  min: 19          ",
+                "                                        max: 96          ",
+                "                                        mean: 43.20      ",
+                "                  gender    Categorical Categories: F, M ",
+                "---------------------------------------------------------",
+            ]
+        ) == str(medrecord.overview_nodes(groups="patient"))
+
     def test_overview_edges(self) -> None:
         medrecord = MedRecord.from_simple_example_dataset()
+
+        assert "\n".join(
+            [
+                "--------------------------------------------------------------------------",
+                "Edges Group       Count Attribute     Type       Data                     ",
+                "--------------------------------------------------------------------------",
+                "patient_diagnosis 1     duration_days Continuous min: 1113.00             ",
+                "                                                 max: 1113.00             ",
+                "                                                 mean: 1113.00            ",
+                "                        time          Temporal   min: 2014-04-08 00:00:00 ",
+                "                                                 max: 2014-04-08 00:00:00 ",
+                "--------------------------------------------------------------------------",
+            ]
+        ) == str(medrecord.overview_edges(edges=1))
+
+        def query(edge: EdgeOperand) -> None:
+            edge.either_or(
+                lambda edge: edge.has_attribute("cost"),
+                lambda edge: edge.has_attribute("duration_minutes"),
+            )
+
+        assert "\n".join(
+            [
+                "-----------------------------------------------------------------------------",
+                "Edges Group       Count Attribute        Type       Data                     ",
+                "-----------------------------------------------------------------------------",
+                "patient_drug      50    cost             Continuous min: 0.10                ",
+                "                                                    max: 7822.20             ",
+                "                                                    mean: 412.10             ",
+                "                        quantity         Continuous min: 1                   ",
+                "                                                    max: 12                  ",
+                "                                                    mean: 2.96               ",
+                "                        time             Temporal   min: 1995-03-26 02:00:40 ",
+                "                                                    max: 2024-04-12 11:59:55 ",
+                "patient_procedure 50    duration_minutes Continuous min: 4.00                ",
+                "                                                    max: 59.00               ",
+                "                                                    mean: 19.44              ",
+                "                        time             Temporal   min: 1993-03-14 02:42:31 ",
+                "                                                    max: 2024-04-24 03:38:35 ",
+                "-----------------------------------------------------------------------------",
+            ]
+        ) == str(medrecord.overview_edges(edges=query))
 
         assert "\n".join(
             [

--- a/medmodels/medrecord/tests/test_medrecord.py
+++ b/medmodels/medrecord/tests/test_medrecord.py
@@ -1897,7 +1897,6 @@ class TestMedRecord(unittest.TestCase):
                     "lorem": {"type": "Categorical", "values": "Categories: ipsum"},
                 },
             },
-            "Float": {"count": 0, "attribute": {}},
             "Ungrouped Nodes": {
                 "count": 1,
                 "attribute": {},
@@ -1994,7 +1993,7 @@ class TestMedRecord(unittest.TestCase):
                 "                                                 max: 2024-04-12 00:00:00 ",
                 "--------------------------------------------------------------------------",
             ]
-        ) == str(medrecord.overview_edges(group="patient_diagnosis"))
+        ) == str(medrecord.overview_edges(groups="patient_diagnosis"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The way this is refactored:

- `overview_nodes()` takes nodes and groups, following this logic for getting the summary (Overview Table)
    - In case only nodes are provided, the method returns a summary of those nodes
            with respect to the groups they belong to. If one node belongs to multiple
            groups, it is counted in each group.
    - If only groups are provided, the method returns a summary of all nodes in the
            specified groups.
    - In case both nodes and groups are provided, the method returns a summary of
            the nodes in the specified groups.

Same logic works for `overview_edges()`.