### PR TITLE
refactor: query engine return types

### DIFF
--- a/crates/medmodels-core/src/medrecord/mod.rs
+++ b/crates/medmodels-core/src/medrecord/mod.rs
@@ -12,8 +12,10 @@ pub use self::{
     group_mapping::Group,
     querying::{
         attributes::{
-            AttributesTreeOperand, MultipleAttributesComparisonOperand, MultipleAttributesOperand,
-            SingleAttributeComparisonOperand, SingleAttributeOperand,
+            AttributesTreeOperand, EdgeAttributesTreeOperand, EdgeMultipleAttributesOperand,
+            EdgeSingleAttributeOperand, MultipleAttributesComparisonOperand,
+            MultipleAttributesOperand, NodeAttributesTreeOperand, NodeMultipleAttributesOperand,
+            NodeSingleAttributeOperand, SingleAttributeComparisonOperand, SingleAttributeOperand,
         },
         edges::{
             EdgeIndexComparisonOperand, EdgeIndexOperand, EdgeIndicesComparisonOperand,
@@ -25,11 +27,12 @@ pub use self::{
         },
         traits::DeepClone,
         values::{
-            MultipleValuesComparisonOperand, MultipleValuesOperand, SingleValueComparisonOperand,
-            SingleValueOperand,
+            EdgeMultipleValuesOperand, EdgeSingleValueOperand, MultipleValuesComparisonOperand,
+            MultipleValuesOperand, NodeMultipleValuesOperand, NodeSingleValueOperand,
+            SingleValueComparisonOperand, SingleValueOperand,
         },
         wrapper::{CardinalityWrapper, Wrapper},
-        OptionalIndexWrapper, ReturnOperand, ReturnValue, Selection,
+        OptionalIndexWrapper, ReturnOperand, Selection,
     },
     schema::{AttributeDataType, AttributeSchema, AttributeType, GroupSchema, Schema, SchemaType},
 };
@@ -905,18 +908,18 @@ impl MedRecord {
         self.group_mapping.clear();
     }
 
-    pub fn query_nodes<Q, R>(&self, query: Q) -> Selection
+    pub fn query_nodes<'a, Q, R>(&'a self, query: Q) -> Selection<'a, R>
     where
         Q: FnOnce(&mut Wrapper<NodeOperand>) -> R,
-        R: Into<ReturnOperand>,
+        R: ReturnOperand<'a>,
     {
         Selection::new_node(self, query)
     }
 
-    pub fn query_edges<Q, R>(&self, query: Q) -> Selection
+    pub fn query_edges<'a, Q, R>(&'a self, query: Q) -> Selection<'a, R>
     where
         Q: FnOnce(&mut Wrapper<EdgeOperand>) -> R,
-        R: Into<ReturnOperand>,
+        R: ReturnOperand<'a>,
     {
         Selection::new_edge(self, query)
     }

--- a/crates/medmodels-core/src/medrecord/querying/values/mod.rs
+++ b/crates/medmodels-core/src/medrecord/querying/values/mod.rs
@@ -146,7 +146,6 @@ impl GetValues<EdgeIndex> for EdgeOperand {
     }
 }
 
-#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone)]
 pub enum Context<O: Operand> {
     Operand((O, MedRecordAttribute)),

--- a/medmodels/medrecord/querying.py
+++ b/medmodels/medrecord/querying.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Callable, Dict, List, Optional, Tuple, TypeAlias, Union
+from typing import Callable, Dict, List, Optional, Sequence, Tuple, TypeAlias, Union
 
 from medmodels._medmodels import (
     PyEdgeAttributesTreeOperand,
@@ -47,10 +47,11 @@ PyQueryReturnOperand: TypeAlias = Union[
     PyEdgeMultipleValuesOperand,
     PyNodeSingleValueOperand,
     PyEdgeSingleValueOperand,
+    Sequence["PyQueryReturnOperand"],
 ]
 
 #: A type alias for a query return operand.
-QueryReturnOperand = Union[
+QueryReturnOperand: TypeAlias = Union[
     "NodeAttributesTreeOperand",
     "EdgeAttributesTreeOperand",
     "NodeMultipleAttributesOperand",
@@ -65,45 +66,46 @@ QueryReturnOperand = Union[
     "EdgeMultipleValuesOperand",
     "NodeSingleValueOperand",
     "EdgeSingleValueOperand",
+    Sequence["QueryReturnOperand"],
 ]
 
-NodeAttributesTreeQueryResult = Dict[NodeIndex, List[MedRecordAttribute]]
-EdgeAttributesTreeQueryResult = Dict[EdgeIndex, List[MedRecordAttribute]]
+NodeAttributesTreeQueryResult: TypeAlias = Dict[NodeIndex, List[MedRecordAttribute]]
+EdgeAttributesTreeQueryResult: TypeAlias = Dict[EdgeIndex, List[MedRecordAttribute]]
 
-NodeMultipleAttributesQueryResult = Dict[NodeIndex, MedRecordAttribute]
-EdgeMultipleAttributesQueryResult = Dict[EdgeIndex, MedRecordAttribute]
+NodeMultipleAttributesQueryResult: TypeAlias = Dict[NodeIndex, MedRecordAttribute]
+EdgeMultipleAttributesQueryResult: TypeAlias = Dict[EdgeIndex, MedRecordAttribute]
 
-NodeSingleAttributeQueryResult = Union[
+NodeSingleAttributeQueryResult: TypeAlias = Union[
     Optional[Tuple[NodeIndex, MedRecordAttribute]],
     Optional[MedRecordAttribute],
 ]
-EdgeSingleAttributeQueryResult = Union[
+EdgeSingleAttributeQueryResult: TypeAlias = Union[
     Optional[Tuple[EdgeIndex, MedRecordAttribute]],
     Optional[MedRecordAttribute],
 ]
 
-EdgeIndicesQueryResult = List[EdgeIndex]
+EdgeIndicesQueryResult: TypeAlias = List[EdgeIndex]
 
-EdgeIndexQueryResult = Optional[EdgeIndex]
+EdgeIndexQueryResult: TypeAlias = Optional[EdgeIndex]
 
-NodeIndicesQueryResult = List[NodeIndex]
+NodeIndicesQueryResult: TypeAlias = List[NodeIndex]
 
-NodeIndexQueryResult = Optional[NodeIndex]
+NodeIndexQueryResult: TypeAlias = Optional[NodeIndex]
 
-NodeMultipleValuesQueryResult = Dict[NodeIndex, MedRecordValue]
-EdgeMultipleValuesQueryResult = Dict[EdgeIndex, MedRecordValue]
+NodeMultipleValuesQueryResult: TypeAlias = Dict[NodeIndex, MedRecordValue]
+EdgeMultipleValuesQueryResult: TypeAlias = Dict[EdgeIndex, MedRecordValue]
 
-NodeSingleValueQueryResult = Union[
+NodeSingleValueQueryResult: TypeAlias = Union[
     Optional[Tuple[NodeIndex, MedRecordValue]],
     Optional[MedRecordValue],
 ]
-EdgeSingleValueQueryResult = Union[
+EdgeSingleValueQueryResult: TypeAlias = Union[
     Optional[Tuple[EdgeIndex, MedRecordValue]],
     Optional[MedRecordValue],
 ]
 
 #: A type alias for a query result.
-QueryResult = Union[
+QueryResult: TypeAlias = Union[
     NodeAttributesTreeQueryResult,
     EdgeAttributesTreeQueryResult,
     NodeMultipleAttributesQueryResult,
@@ -118,6 +120,7 @@ QueryResult = Union[
     EdgeMultipleValuesQueryResult,
     NodeSingleValueQueryResult,
     EdgeSingleValueQueryResult,
+    List["QueryResult"],
 ]
 
 NodeQuery: TypeAlias = Callable[["NodeOperand"], QueryReturnOperand]

--- a/medmodels/medrecord/types.py
+++ b/medmodels/medrecord/types.py
@@ -193,6 +193,19 @@ def is_node_index(value: object) -> TypeIs[NodeIndex]:
     return is_medrecord_attribute(value)
 
 
+def is_node_index_list(value: object) -> TypeIs[NodeIndexInputList]:
+    """Check if a value is a valid list of node indices.
+
+    Args:
+        value (object): The value to check.
+
+    Returns:
+        TypeIs[NodeIndexInputList]: True if the value is a valid list of node indices,
+            otherwise False.
+    """
+    return isinstance(value, list) and all(is_node_index(input) for input in value)
+
+
 def is_edge_index(value: object) -> TypeIs[EdgeIndex]:
     """Check if a value is a valid edge index.
 
@@ -203,6 +216,19 @@ def is_edge_index(value: object) -> TypeIs[EdgeIndex]:
         TypeIs[EdgeIndex]: True if the value is a valid edge index, otherwise False.
     """
     return isinstance(value, int)
+
+
+def is_edge_index_list(value: object) -> TypeIs[EdgeIndexInputList]:
+    """Check if a value is a valid list of edge indices.
+
+    Args:
+        value (object): The value to check.
+
+    Returns:
+        TypeIs[EdgeIndexInputList]: True if the value is a valid list of edge indices,
+            otherwise False.
+    """
+    return isinstance(value, list) and all(is_edge_index(input) for input in value)
 
 
 def is_group(value: object) -> TypeIs[Group]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["D", "DOC"]
+"tests/*" = ["D", "DOC", "C901"]
 "*/__init__.py" = ["D", "DOC"]
 
 [tool.ruff.lint.pydocstyle]

--- a/rustmodels/src/medrecord/datatype.rs
+++ b/rustmodels/src/medrecord/datatype.rs
@@ -81,7 +81,9 @@ pub(crate) fn convert_pyobject_to_datatype(ob: &Bound<'_, pyo3::PyAny>) -> PyRes
     }
 
     fn convert_union(ob: &Bound<'_, pyo3::PyAny>) -> PyResult<DataType> {
-        let union = ob.extract::<PyRef<PyUnion>>()?;
+        let union = ob
+            .extract::<PyRef<PyUnion>>()
+            .expect("Extraction must succeed");
 
         let dtypes = union.0.clone();
 
@@ -92,7 +94,9 @@ pub(crate) fn convert_pyobject_to_datatype(ob: &Bound<'_, pyo3::PyAny>) -> PyRes
     }
 
     fn convert_option(ob: &Bound<'_, pyo3::PyAny>) -> PyResult<DataType> {
-        let option = ob.extract::<PyRef<PyOption>>()?;
+        let option = ob
+            .extract::<PyRef<PyOption>>()
+            .expect("Extraction must succeed");
 
         Ok(DataType::Option(Box::new(option.0.clone().into())))
     }

--- a/rustmodels/src/medrecord/mod.rs
+++ b/rustmodels/src/medrecord/mod.rs
@@ -708,7 +708,7 @@ impl PyMedRecord {
 
                 result
                     .extract::<PyReturnOperand>()
-                    .expect("Extract must succeed")
+                    .expect("Extraction must succeed")
             })
             .evaluate()
             .map_err(PyMedRecordError::from)?)
@@ -724,7 +724,7 @@ impl PyMedRecord {
 
                 result
                     .extract::<PyReturnOperand>()
-                    .expect("Extract must succeed")
+                    .expect("Extraction must succeed")
             })
             .evaluate()
             .map_err(PyMedRecordError::from)?)

--- a/rustmodels/src/medrecord/mod.rs
+++ b/rustmodels/src/medrecord/mod.rs
@@ -17,7 +17,7 @@ use medmodels_core::{
 };
 use pyo3::{prelude::*, types::PyFunction};
 use pyo3_polars::PyDataFrame;
-use querying::{edges::PyEdgeOperand, nodes::PyNodeOperand, parse_query_result, PyReturnValue};
+use querying::{edges::PyEdgeOperand, nodes::PyNodeOperand, PyReturnOperand, PyReturnValue};
 use schema::PySchema;
 use std::collections::HashMap;
 use traits::DeepInto;
@@ -706,11 +706,12 @@ impl PyMedRecord {
                     .call1((PyNodeOperand::from(node.clone()),))
                     .expect("Call must succeed");
 
-                parse_query_result(result)
+                result
+                    .extract::<PyReturnOperand>()
+                    .expect("Extract must succeed")
             })
             .evaluate()
-            .map_err(PyMedRecordError::from)?
-            .into())
+            .map_err(PyMedRecordError::from)?)
     }
 
     pub fn query_edges(&self, query: &Bound<'_, PyFunction>) -> PyResult<PyReturnValue> {
@@ -721,11 +722,12 @@ impl PyMedRecord {
                     .call1((PyEdgeOperand::from(edge.clone()),))
                     .expect("Call must succeed");
 
-                parse_query_result(result)
+                result
+                    .extract::<PyReturnOperand>()
+                    .expect("Extract must succeed")
             })
             .evaluate()
-            .map_err(PyMedRecordError::from)?
-            .into())
+            .map_err(PyMedRecordError::from)?)
     }
 
     pub fn clone(&self) -> Self {

--- a/rustmodels/src/medrecord/querying/attributes.rs
+++ b/rustmodels/src/medrecord/querying/attributes.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use super::values::{PyEdgeMultipleValuesOperand, PyNodeMultipleValuesOperand};
 use crate::medrecord::{attribute::PyMedRecordAttribute, errors::PyMedRecordError};
 use medmodels_core::{
@@ -26,6 +28,14 @@ impl From<SingleAttributeComparisonOperand> for PySingleAttributeComparisonOpera
 impl From<PySingleAttributeComparisonOperand> for SingleAttributeComparisonOperand {
     fn from(operand: PySingleAttributeComparisonOperand) -> Self {
         operand.0
+    }
+}
+
+impl Deref for PySingleAttributeComparisonOperand {
+    type Target = SingleAttributeComparisonOperand;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -61,6 +71,14 @@ impl From<MultipleAttributesComparisonOperand> for PyMultipleAttributesCompariso
 impl From<PyMultipleAttributesComparisonOperand> for MultipleAttributesComparisonOperand {
     fn from(operand: PyMultipleAttributesComparisonOperand) -> Self {
         operand.0
+    }
+}
+
+impl Deref for PyMultipleAttributesComparisonOperand {
+    type Target = MultipleAttributesComparisonOperand;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -103,6 +121,14 @@ macro_rules! implement_attributes_tree_operand {
         impl From<$name> for Wrapper<AttributesTreeOperand<$generic>> {
             fn from(operand: $name) -> Self {
                 operand.0
+            }
+        }
+
+        impl Deref for $name {
+            type Target = Wrapper<AttributesTreeOperand<$generic>>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
             }
         }
 
@@ -296,6 +322,14 @@ macro_rules! implement_multiple_attributes_operand {
         impl From<$name> for Wrapper<MultipleAttributesOperand<$generic>> {
             fn from(operand: $name) -> Self {
                 operand.0
+            }
+        }
+
+        impl Deref for $name {
+            type Target = Wrapper<MultipleAttributesOperand<$generic>>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
             }
         }
 
@@ -495,6 +529,14 @@ macro_rules! implement_single_attribute_operand {
         impl From<$name> for Wrapper<SingleAttributeOperand<$generic>> {
             fn from(operand: $name) -> Self {
                 operand.0
+            }
+        }
+
+        impl Deref for $name {
+            type Target = Wrapper<SingleAttributeOperand<$generic>>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
             }
         }
 

--- a/rustmodels/src/medrecord/querying/mod.rs
+++ b/rustmodels/src/medrecord/querying/mod.rs
@@ -3,9 +3,11 @@ pub mod edges;
 pub mod nodes;
 pub mod values;
 
+use crate::gil_hash_map::GILHashMap;
+
 use super::{
     attribute::PyMedRecordAttribute, errors::PyMedRecordError, traits::DeepFrom,
-    value::PyMedRecordValue, PyNodeIndex,
+    value::PyMedRecordValue, Lut, PyNodeIndex,
 };
 use attributes::{
     PyEdgeAttributesTreeOperand, PyEdgeMultipleAttributesOperand, PyEdgeSingleAttributeOperand,
@@ -13,14 +15,20 @@ use attributes::{
 };
 use edges::{PyEdgeIndexOperand, PyEdgeIndicesOperand};
 use medmodels_core::{
-    errors::MedRecordError,
+    errors::{MedRecordError, MedRecordResult},
     medrecord::{
-        CardinalityWrapper, MedRecordAttribute, OptionalIndexWrapper, ReturnOperand, ReturnValue,
+        CardinalityWrapper, EdgeAttributesTreeOperand, EdgeIndexOperand, EdgeIndicesOperand,
+        EdgeMultipleAttributesOperand, EdgeMultipleValuesOperand, EdgeSingleAttributeOperand,
+        EdgeSingleValueOperand, MedRecordAttribute, NodeAttributesTreeOperand, NodeIndexOperand,
+        NodeIndicesOperand, NodeMultipleAttributesOperand, NodeMultipleValuesOperand,
+        NodeSingleAttributeOperand, NodeSingleValueOperand, OptionalIndexWrapper, ReturnOperand,
+        Wrapper,
     },
+    MedRecord,
 };
 use nodes::{PyNodeIndexOperand, PyNodeIndicesOperand};
 use pyo3::{
-    types::{PyAnyMethods, PyNone},
+    types::{PyAnyMethods, PyList, PyNone},
     Bound, FromPyObject, IntoPyObject, IntoPyObjectExt, PyAny, PyErr, PyResult, Python,
 };
 use std::collections::HashMap;
@@ -29,123 +37,298 @@ use values::{
     PyNodeSingleValueOperand,
 };
 
-pub fn parse_query_result(result: Bound<'_, PyAny>) -> ReturnOperand {
-    if result.is_instance_of::<PyNodeAttributesTreeOperand>() {
-        ReturnOperand::NodeAttributesTree(
-            result
-                .extract::<PyNodeAttributesTreeOperand>()
-                .expect("Extract must succeed")
-                .into(),
-        )
-    } else if result.is_instance_of::<PyEdgeAttributesTreeOperand>() {
-        ReturnOperand::EdgeAttributesTree(
-            result
-                .extract::<PyEdgeAttributesTreeOperand>()
-                .expect("Extract must succeed")
-                .into(),
-        )
-    } else if result.is_instance_of::<PyNodeMultipleAttributesOperand>() {
-        ReturnOperand::NodeMultipleAttributes(
-            result
-                .extract::<PyNodeMultipleAttributesOperand>()
-                .expect("Extract must succeed")
-                .into(),
-        )
-    } else if result.is_instance_of::<PyEdgeMultipleAttributesOperand>() {
-        ReturnOperand::EdgeMultipleAttributes(
-            result
-                .extract::<PyEdgeMultipleAttributesOperand>()
-                .expect("Extract must succeed")
-                .into(),
-        )
-    } else if result.is_instance_of::<PyNodeSingleAttributeOperand>() {
-        ReturnOperand::NodeSingleAttribute(
-            result
-                .extract::<PyNodeSingleAttributeOperand>()
-                .expect("Extract must succeed")
-                .into(),
-        )
-    } else if result.is_instance_of::<PyEdgeSingleAttributeOperand>() {
-        ReturnOperand::EdgeSingleAttribute(
-            result
-                .extract::<PyEdgeSingleAttributeOperand>()
-                .expect("Extract must succeed")
-                .into(),
-        )
-    } else if result.is_instance_of::<PyEdgeIndicesOperand>() {
-        ReturnOperand::EdgeIndices(
-            result
-                .extract::<PyEdgeIndicesOperand>()
-                .expect("Extract must succeed")
-                .into(),
-        )
-    } else if result.is_instance_of::<PyEdgeIndexOperand>() {
-        ReturnOperand::EdgeIndex(
-            result
-                .extract::<PyEdgeIndexOperand>()
-                .expect("Extract must succeed")
-                .into(),
-        )
-    } else if result.is_instance_of::<PyNodeIndicesOperand>() {
-        ReturnOperand::NodeIndices(
-            result
-                .extract::<PyNodeIndicesOperand>()
-                .expect("Extract must succeed")
-                .into(),
-        )
-    } else if result.is_instance_of::<PyNodeIndexOperand>() {
-        ReturnOperand::NodeIndex(
-            result
-                .extract::<PyNodeIndexOperand>()
-                .expect("Extract must succeed")
-                .into(),
-        )
-    } else if result.is_instance_of::<PyNodeMultipleValuesOperand>() {
-        ReturnOperand::NodeMultipleValues(
-            result
-                .extract::<PyNodeMultipleValuesOperand>()
-                .expect("Extract must succeed")
-                .into(),
-        )
-    } else if result.is_instance_of::<PyEdgeMultipleValuesOperand>() {
-        ReturnOperand::EdgeMultipleValues(
-            result
-                .extract::<PyEdgeMultipleValuesOperand>()
-                .expect("Extract must succeed")
-                .into(),
-        )
-    } else if result.is_instance_of::<PyNodeSingleValueOperand>() {
-        ReturnOperand::NodeSingleValue(
-            result
-                .extract::<PyNodeSingleValueOperand>()
-                .expect("Extract must succeed")
-                .into(),
-        )
-    } else if result.is_instance_of::<PyEdgeSingleValueOperand>() {
-        ReturnOperand::EdgeSingleValue(
-            result
-                .extract::<PyEdgeSingleValueOperand>()
-                .expect("Extract must succeed")
-                .into(),
-        )
-    } else {
-        panic!("Query function is not a valid NodeQueryFunction")
+pub enum PyReturnOperand {
+    NodeAttributesTree(PyNodeAttributesTreeOperand),
+    EdgeAttributesTree(PyEdgeAttributesTreeOperand),
+    NodeMultipleAttributes(PyNodeMultipleAttributesOperand),
+    EdgeMultipleAttributes(PyEdgeMultipleAttributesOperand),
+    NodeSingleAttribute(PyNodeSingleAttributeOperand),
+    EdgeSingleAttribute(PyEdgeSingleAttributeOperand),
+    EdgeIndices(PyEdgeIndicesOperand),
+    EdgeIndex(PyEdgeIndexOperand),
+    NodeIndices(PyNodeIndicesOperand),
+    NodeIndex(PyNodeIndexOperand),
+    NodeMultipleValues(PyNodeMultipleValuesOperand),
+    EdgeMultipleValues(PyEdgeMultipleValuesOperand),
+    NodeSingleValue(PyNodeSingleValueOperand),
+    EdgeSingleValue(PyEdgeSingleValueOperand),
+    Vector(Vec<Self>),
+}
+
+impl<'a> ReturnOperand<'a> for PyReturnOperand {
+    type ReturnValue = PyReturnValue<'a>;
+
+    fn evaluate(self, medrecord: &'a MedRecord) -> MedRecordResult<Self::ReturnValue> {
+        match self {
+            PyReturnOperand::NodeAttributesTree(operand) => {
+                Wrapper::<NodeAttributesTreeOperand>::from(operand)
+                    .evaluate(medrecord)
+                    .map(PyReturnValue::NodeAttributesTree)
+            }
+            PyReturnOperand::EdgeAttributesTree(operand) => {
+                Wrapper::<EdgeAttributesTreeOperand>::from(operand)
+                    .evaluate(medrecord)
+                    .map(PyReturnValue::EdgeAttributesTree)
+            }
+            PyReturnOperand::NodeMultipleAttributes(operand) => {
+                Wrapper::<NodeMultipleAttributesOperand>::from(operand)
+                    .evaluate(medrecord)
+                    .map(PyReturnValue::NodeMultipleAttributes)
+            }
+            PyReturnOperand::EdgeMultipleAttributes(operand) => {
+                Wrapper::<EdgeMultipleAttributesOperand>::from(operand)
+                    .evaluate(medrecord)
+                    .map(PyReturnValue::EdgeMultipleAttributes)
+            }
+            PyReturnOperand::NodeSingleAttribute(operand) => {
+                Wrapper::<NodeSingleAttributeOperand>::from(operand)
+                    .evaluate(medrecord)
+                    .map(PyReturnValue::NodeSingleAttribute)
+            }
+            PyReturnOperand::EdgeSingleAttribute(operand) => {
+                Wrapper::<EdgeSingleAttributeOperand>::from(operand)
+                    .evaluate(medrecord)
+                    .map(PyReturnValue::EdgeSingleAttribute)
+            }
+            PyReturnOperand::EdgeIndices(operand) => Wrapper::<EdgeIndicesOperand>::from(operand)
+                .evaluate(medrecord)
+                .map(PyReturnValue::EdgeIndices),
+            PyReturnOperand::EdgeIndex(operand) => Wrapper::<EdgeIndexOperand>::from(operand)
+                .evaluate(medrecord)
+                .map(PyReturnValue::EdgeIndex),
+            PyReturnOperand::NodeIndices(operand) => Wrapper::<NodeIndicesOperand>::from(operand)
+                .evaluate(medrecord)
+                .map(PyReturnValue::NodeIndices),
+            PyReturnOperand::NodeIndex(operand) => Wrapper::<NodeIndexOperand>::from(operand)
+                .evaluate(medrecord)
+                .map(PyReturnValue::NodeIndex),
+            PyReturnOperand::NodeMultipleValues(operand) => {
+                Wrapper::<NodeMultipleValuesOperand>::from(operand)
+                    .evaluate(medrecord)
+                    .map(PyReturnValue::NodeMultipleValues)
+            }
+            PyReturnOperand::EdgeMultipleValues(operand) => {
+                Wrapper::<EdgeMultipleValuesOperand>::from(operand)
+                    .evaluate(medrecord)
+                    .map(PyReturnValue::EdgeMultipleValues)
+            }
+            PyReturnOperand::NodeSingleValue(operand) => {
+                Wrapper::<NodeSingleValueOperand>::from(operand)
+                    .evaluate(medrecord)
+                    .map(PyReturnValue::NodeSingleValue)
+            }
+            PyReturnOperand::EdgeSingleValue(operand) => {
+                Wrapper::<EdgeSingleValueOperand>::from(operand)
+                    .evaluate(medrecord)
+                    .map(PyReturnValue::EdgeSingleValue)
+            }
+            PyReturnOperand::Vector(operand) => operand
+                .into_iter()
+                .map(|item| item.evaluate(medrecord))
+                .collect::<MedRecordResult<Vec<_>>>()
+                .map(PyReturnValue::Vector),
+        }
     }
 }
 
-#[repr(transparent)]
-pub struct PyReturnValue<'a>(ReturnValue<'a>);
+static RETURNOPERAND_CONVERSION_LUT: Lut<PyReturnOperand> = GILHashMap::new();
 
-impl<'a> From<ReturnValue<'a>> for PyReturnValue<'a> {
-    fn from(value: ReturnValue<'a>) -> Self {
-        Self(value)
+pub(crate) fn convert_pyobject_to_pyreturnoperand(
+    ob: &Bound<'_, PyAny>,
+) -> PyResult<PyReturnOperand> {
+    fn convert_py_node_attributes_tree_operand(ob: &Bound<'_, PyAny>) -> PyResult<PyReturnOperand> {
+        Ok(PyReturnOperand::NodeAttributesTree(
+            ob.extract::<PyNodeAttributesTreeOperand>()
+                .expect("Extraction must succeed"),
+        ))
+    }
+
+    fn convert_py_edge_attributes_tree_operand(ob: &Bound<'_, PyAny>) -> PyResult<PyReturnOperand> {
+        Ok(PyReturnOperand::EdgeAttributesTree(
+            ob.extract::<PyEdgeAttributesTreeOperand>()
+                .expect("Extraction must succeed"),
+        ))
+    }
+
+    fn convert_py_node_multiple_attributes_operand(
+        ob: &Bound<'_, PyAny>,
+    ) -> PyResult<PyReturnOperand> {
+        Ok(PyReturnOperand::NodeMultipleAttributes(
+            ob.extract::<PyNodeMultipleAttributesOperand>()
+                .expect("Extraction must succeed"),
+        ))
+    }
+
+    fn convert_py_edge_multiple_attributes_operand(
+        ob: &Bound<'_, PyAny>,
+    ) -> PyResult<PyReturnOperand> {
+        Ok(PyReturnOperand::EdgeMultipleAttributes(
+            ob.extract::<PyEdgeMultipleAttributesOperand>()
+                .expect("Extraction must succeed"),
+        ))
+    }
+
+    fn convert_py_node_single_attribute_operand(
+        ob: &Bound<'_, PyAny>,
+    ) -> PyResult<PyReturnOperand> {
+        Ok(PyReturnOperand::NodeSingleAttribute(
+            ob.extract::<PyNodeSingleAttributeOperand>()
+                .expect("Extraction must succeed"),
+        ))
+    }
+
+    fn convert_py_edge_single_attribute_operand(
+        ob: &Bound<'_, PyAny>,
+    ) -> PyResult<PyReturnOperand> {
+        Ok(PyReturnOperand::EdgeSingleAttribute(
+            ob.extract::<PyEdgeSingleAttributeOperand>()
+                .expect("Extraction must succeed"),
+        ))
+    }
+
+    fn convert_py_edge_indices_operand(ob: &Bound<'_, PyAny>) -> PyResult<PyReturnOperand> {
+        Ok(PyReturnOperand::EdgeIndices(
+            ob.extract::<PyEdgeIndicesOperand>()
+                .expect("Extraction must succeed"),
+        ))
+    }
+
+    fn convert_py_edge_index_operand(ob: &Bound<'_, PyAny>) -> PyResult<PyReturnOperand> {
+        Ok(PyReturnOperand::EdgeIndex(
+            ob.extract::<PyEdgeIndexOperand>()
+                .expect("Extraction must succeed"),
+        ))
+    }
+
+    fn convert_py_node_indices_operand(ob: &Bound<'_, PyAny>) -> PyResult<PyReturnOperand> {
+        Ok(PyReturnOperand::NodeIndices(
+            ob.extract::<PyNodeIndicesOperand>()
+                .expect("Extraction must succeed"),
+        ))
+    }
+
+    fn convert_py_node_index_operand(ob: &Bound<'_, PyAny>) -> PyResult<PyReturnOperand> {
+        Ok(PyReturnOperand::NodeIndex(
+            ob.extract::<PyNodeIndexOperand>()
+                .expect("Extraction must succeed"),
+        ))
+    }
+
+    fn convert_py_node_multiple_values_operand(ob: &Bound<'_, PyAny>) -> PyResult<PyReturnOperand> {
+        Ok(PyReturnOperand::NodeMultipleValues(
+            ob.extract::<PyNodeMultipleValuesOperand>()
+                .expect("Extraction must succeed"),
+        ))
+    }
+
+    fn convert_py_edge_multiple_values_operand(ob: &Bound<'_, PyAny>) -> PyResult<PyReturnOperand> {
+        Ok(PyReturnOperand::EdgeMultipleValues(
+            ob.extract::<PyEdgeMultipleValuesOperand>()
+                .expect("Extraction must succeed"),
+        ))
+    }
+
+    fn convert_py_node_single_value_operand(ob: &Bound<'_, PyAny>) -> PyResult<PyReturnOperand> {
+        Ok(PyReturnOperand::NodeSingleValue(
+            ob.extract::<PyNodeSingleValueOperand>()
+                .expect("Extraction must succeed"),
+        ))
+    }
+
+    fn convert_py_edge_single_value_operand(ob: &Bound<'_, PyAny>) -> PyResult<PyReturnOperand> {
+        Ok(PyReturnOperand::EdgeSingleValue(
+            ob.extract::<PyEdgeSingleValueOperand>()
+                .expect("Extraction must succeed"),
+        ))
+    }
+
+    fn convert_py_list(ob: &Bound<'_, PyAny>) -> PyResult<PyReturnOperand> {
+        Ok(PyReturnOperand::Vector(
+            ob.extract::<Vec<PyReturnOperand>>()?,
+        ))
+    }
+
+    fn throw_error(ob: &Bound<'_, PyAny>) -> PyResult<PyReturnOperand> {
+        Err(
+            PyMedRecordError::from(MedRecordError::ConversionError(format!(
+                "Failed to convert {} into query ReturnOperand",
+                ob,
+            )))
+            .into(),
+        )
+    }
+
+    let type_pointer = ob.get_type_ptr() as usize;
+
+    Python::with_gil(|py| {
+        RETURNOPERAND_CONVERSION_LUT.map(py, |lut| {
+            let conversion_function = lut.entry(type_pointer).or_insert_with(|| {
+                if ob.is_instance_of::<PyNodeAttributesTreeOperand>() {
+                    convert_py_node_attributes_tree_operand
+                } else if ob.is_instance_of::<PyEdgeAttributesTreeOperand>() {
+                    convert_py_edge_attributes_tree_operand
+                } else if ob.is_instance_of::<PyNodeMultipleAttributesOperand>() {
+                    convert_py_node_multiple_attributes_operand
+                } else if ob.is_instance_of::<PyEdgeMultipleAttributesOperand>() {
+                    convert_py_edge_multiple_attributes_operand
+                } else if ob.is_instance_of::<PyNodeSingleAttributeOperand>() {
+                    convert_py_node_single_attribute_operand
+                } else if ob.is_instance_of::<PyEdgeSingleAttributeOperand>() {
+                    convert_py_edge_single_attribute_operand
+                } else if ob.is_instance_of::<PyEdgeIndicesOperand>() {
+                    convert_py_edge_indices_operand
+                } else if ob.is_instance_of::<PyEdgeIndexOperand>() {
+                    convert_py_edge_index_operand
+                } else if ob.is_instance_of::<PyNodeIndicesOperand>() {
+                    convert_py_node_indices_operand
+                } else if ob.is_instance_of::<PyNodeIndexOperand>() {
+                    convert_py_node_index_operand
+                } else if ob.is_instance_of::<PyNodeMultipleValuesOperand>() {
+                    convert_py_node_multiple_values_operand
+                } else if ob.is_instance_of::<PyEdgeMultipleValuesOperand>() {
+                    convert_py_edge_multiple_values_operand
+                } else if ob.is_instance_of::<PyNodeSingleValueOperand>() {
+                    convert_py_node_single_value_operand
+                } else if ob.is_instance_of::<PyEdgeSingleValueOperand>() {
+                    convert_py_edge_single_value_operand
+                } else if ob.is_instance_of::<PyList>() {
+                    convert_py_list
+                } else {
+                    throw_error
+                }
+            });
+
+            conversion_function(ob)
+        })
+    })
+}
+
+impl FromPyObject<'_> for PyReturnOperand {
+    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
+        convert_pyobject_to_pyreturnoperand(ob)
     }
 }
 
-impl<'a> From<PyReturnValue<'a>> for ReturnValue<'a> {
-    fn from(value: PyReturnValue<'a>) -> Self {
-        value.0
-    }
+pub enum PyReturnValue<'a> {
+    NodeAttributesTree(<Wrapper<NodeAttributesTreeOperand> as ReturnOperand<'a>>::ReturnValue),
+    EdgeAttributesTree(<Wrapper<EdgeAttributesTreeOperand> as ReturnOperand<'a>>::ReturnValue),
+    NodeMultipleAttributes(
+        <Wrapper<NodeMultipleAttributesOperand> as ReturnOperand<'a>>::ReturnValue,
+    ),
+    EdgeMultipleAttributes(
+        <Wrapper<EdgeMultipleAttributesOperand> as ReturnOperand<'a>>::ReturnValue,
+    ),
+    NodeSingleAttribute(<Wrapper<NodeSingleAttributeOperand> as ReturnOperand<'a>>::ReturnValue),
+    EdgeSingleAttribute(<Wrapper<EdgeSingleAttributeOperand> as ReturnOperand<'a>>::ReturnValue),
+    EdgeIndices(<Wrapper<EdgeIndicesOperand> as ReturnOperand<'a>>::ReturnValue),
+    EdgeIndex(<Wrapper<EdgeIndexOperand> as ReturnOperand<'a>>::ReturnValue),
+    NodeIndices(<Wrapper<NodeIndicesOperand> as ReturnOperand<'a>>::ReturnValue),
+    NodeIndex(<Wrapper<NodeIndexOperand> as ReturnOperand<'a>>::ReturnValue),
+    NodeMultipleValues(<Wrapper<NodeMultipleValuesOperand> as ReturnOperand<'a>>::ReturnValue),
+    EdgeMultipleValues(<Wrapper<EdgeMultipleValuesOperand> as ReturnOperand<'a>>::ReturnValue),
+    NodeSingleValue(<Wrapper<NodeSingleValueOperand> as ReturnOperand<'a>>::ReturnValue),
+    EdgeSingleValue(<Wrapper<EdgeSingleValueOperand> as ReturnOperand<'a>>::ReturnValue),
+    Vector(Vec<Self>),
 }
 
 impl<'py> IntoPyObject<'py> for PyReturnValue<'_> {
@@ -154,8 +337,8 @@ impl<'py> IntoPyObject<'py> for PyReturnValue<'_> {
     type Error = PyErr;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        match self.0 {
-            ReturnValue::NodeAttributesTree(iterator) => iterator
+        match self {
+            PyReturnValue::NodeAttributesTree(iterator) => iterator
                 .map(|item| {
                     (
                         PyNodeIndex::from(item.0.clone()),
@@ -164,11 +347,11 @@ impl<'py> IntoPyObject<'py> for PyReturnValue<'_> {
                 })
                 .collect::<HashMap<_, _>>()
                 .into_bound_py_any(py),
-            ReturnValue::EdgeAttributesTree(iterator) => iterator
+            PyReturnValue::EdgeAttributesTree(iterator) => iterator
                 .map(|item| (item.0, Vec::<PyMedRecordAttribute>::deep_from(item.1)))
                 .collect::<HashMap<_, _>>()
                 .into_bound_py_any(py),
-            ReturnValue::NodeMultipleAttributes(iterator) => iterator
+            PyReturnValue::NodeMultipleAttributes(iterator) => iterator
                 .map(|item| {
                     (
                         PyNodeIndex::from(item.0.clone()),
@@ -177,11 +360,11 @@ impl<'py> IntoPyObject<'py> for PyReturnValue<'_> {
                 })
                 .collect::<HashMap<_, _>>()
                 .into_bound_py_any(py),
-            ReturnValue::EdgeMultipleAttributes(iterator) => iterator
+            PyReturnValue::EdgeMultipleAttributes(iterator) => iterator
                 .map(|item| (item.0, PyMedRecordAttribute::from(item.1)))
                 .collect::<HashMap<_, _>>()
                 .into_bound_py_any(py),
-            ReturnValue::NodeSingleAttribute(attribute) => match attribute {
+            PyReturnValue::NodeSingleAttribute(attribute) => match attribute {
                 Some(attribute) => match attribute {
                     OptionalIndexWrapper::WithIndex((index, attribute)) => (
                         PyNodeIndex::from(index.clone()),
@@ -194,7 +377,7 @@ impl<'py> IntoPyObject<'py> for PyReturnValue<'_> {
                 },
                 None => PyNone::get(py).into_bound_py_any(py),
             },
-            ReturnValue::EdgeSingleAttribute(attribute) => match attribute {
+            PyReturnValue::EdgeSingleAttribute(attribute) => match attribute {
                 Some(attribute) => match attribute {
                     OptionalIndexWrapper::WithIndex((index, attribute)) => {
                         (index, PyMedRecordAttribute::from(attribute)).into_bound_py_any(py)
@@ -205,18 +388,18 @@ impl<'py> IntoPyObject<'py> for PyReturnValue<'_> {
                 },
                 None => PyNone::get(py).into_bound_py_any(py),
             },
-            ReturnValue::EdgeIndices(iterator) => {
+            PyReturnValue::EdgeIndices(iterator) => {
                 iterator.collect::<Vec<_>>().into_bound_py_any(py)
             }
-            ReturnValue::EdgeIndex(index) => index.into_bound_py_any(py),
-            ReturnValue::NodeIndices(iterator) => iterator
+            PyReturnValue::EdgeIndex(index) => index.into_bound_py_any(py),
+            PyReturnValue::NodeIndices(iterator) => iterator
                 .map(PyMedRecordAttribute::from)
                 .collect::<Vec<_>>()
                 .into_bound_py_any(py),
-            ReturnValue::NodeIndex(index) => {
+            PyReturnValue::NodeIndex(index) => {
                 Option::<PyNodeIndex>::deep_from(index).into_bound_py_any(py)
             }
-            ReturnValue::NodeMultipleValues(iterator) => iterator
+            PyReturnValue::NodeMultipleValues(iterator) => iterator
                 .map(|item| {
                     (
                         PyNodeIndex::from(item.0.clone()),
@@ -225,11 +408,11 @@ impl<'py> IntoPyObject<'py> for PyReturnValue<'_> {
                 })
                 .collect::<HashMap<_, _>>()
                 .into_bound_py_any(py),
-            ReturnValue::EdgeMultipleValues(iterator) => iterator
+            PyReturnValue::EdgeMultipleValues(iterator) => iterator
                 .map(|item| (item.0, PyMedRecordValue::from(item.1)))
                 .collect::<HashMap<_, _>>()
                 .into_bound_py_any(py),
-            ReturnValue::NodeSingleValue(value) => match value {
+            PyReturnValue::NodeSingleValue(value) => match value {
                 Some(value) => match value {
                     OptionalIndexWrapper::WithIndex((index, value)) => (
                         PyNodeIndex::from(index.clone()),
@@ -242,7 +425,7 @@ impl<'py> IntoPyObject<'py> for PyReturnValue<'_> {
                 },
                 None => PyNone::get(py).into_bound_py_any(py),
             },
-            ReturnValue::EdgeSingleValue(value) => match value {
+            PyReturnValue::EdgeSingleValue(value) => match value {
                 Some(value) => match value {
                     OptionalIndexWrapper::WithIndex((index, value)) => {
                         (index, PyMedRecordValue::from(value)).into_bound_py_any(py)
@@ -253,6 +436,7 @@ impl<'py> IntoPyObject<'py> for PyReturnValue<'_> {
                 },
                 None => PyNone::get(py).into_bound_py_any(py),
             },
+            PyReturnValue::Vector(vector) => vector.into_bound_py_any(py),
         }
     }
 }

--- a/rustmodels/src/medrecord/value.rs
+++ b/rustmodels/src/medrecord/value.rs
@@ -50,27 +50,40 @@ pub(crate) fn convert_pyobject_to_medrecordvalue(
     ob: &Bound<'_, PyAny>,
 ) -> PyResult<MedRecordValue> {
     fn convert_string(ob: &Bound<'_, PyAny>) -> PyResult<MedRecordValue> {
-        Ok(MedRecordValue::String(ob.extract::<String>()?))
+        Ok(MedRecordValue::String(
+            ob.extract::<String>().expect("Extraction must succeed"),
+        ))
     }
 
     fn convert_int(ob: &Bound<'_, PyAny>) -> PyResult<MedRecordValue> {
-        Ok(MedRecordValue::Int(ob.extract::<i64>()?))
+        Ok(MedRecordValue::Int(
+            ob.extract::<i64>().expect("Extraction must succeed"),
+        ))
     }
 
     fn convert_float(ob: &Bound<'_, PyAny>) -> PyResult<MedRecordValue> {
-        Ok(MedRecordValue::Float(ob.extract::<f64>()?))
+        Ok(MedRecordValue::Float(
+            ob.extract::<f64>().expect("Extraction must succeed"),
+        ))
     }
 
     fn convert_bool(ob: &Bound<'_, PyAny>) -> PyResult<MedRecordValue> {
-        Ok(MedRecordValue::Bool(ob.extract::<bool>()?))
+        Ok(MedRecordValue::Bool(
+            ob.extract::<bool>().expect("Extraction must succeed"),
+        ))
     }
 
     fn convert_datetime(ob: &Bound<'_, PyAny>) -> PyResult<MedRecordValue> {
-        Ok(MedRecordValue::DateTime(ob.extract::<NaiveDateTime>()?))
+        Ok(MedRecordValue::DateTime(
+            ob.extract::<NaiveDateTime>()
+                .expect("Extraction must succeed"),
+        ))
     }
 
     fn convert_duration(ob: &Bound<'_, PyAny>) -> PyResult<MedRecordValue> {
-        Ok(MedRecordValue::Duration(ob.extract::<Duration>()?))
+        Ok(MedRecordValue::Duration(
+            ob.extract::<Duration>().expect("Extraction must succeed"),
+        ))
     }
 
     fn convert_null(_ob: &Bound<'_, PyAny>) -> PyResult<MedRecordValue> {

--- a/tests/medrecord/test_medrecord.py
+++ b/tests/medrecord/test_medrecord.py
@@ -28,9 +28,15 @@ from medmodels.medrecord.querying import (
     NodeOperand,
     NodeSingleAttributeOperand,
     NodeSingleValueOperand,
+    QueryReturnOperand,
 )
 from medmodels.medrecord.schema import AttributeType, GroupSchema, Schema, SchemaType
-from medmodels.medrecord.types import AttributesInput, NodeIndex
+from medmodels.medrecord.types import (
+    AttributesInput,
+    NodeIndex,
+    is_edge_index_list,
+    is_node_index_list,
+)
 
 
 # TODO(#397): Change AttributesInput to Attributes
@@ -2311,6 +2317,15 @@ class TestMedRecord(unittest.TestCase):
 
         assert sorted(medrecord.query_nodes(query9)) == [0, 1, 3]
 
+        def query10(node: NodeOperand) -> List[QueryReturnOperand]:
+            node.index().equal_to("0")
+            return [node.index(), node.edges().index()]
+
+        node_indices, edge_indices = medrecord.query_nodes(query10)
+        assert node_indices == ["0"]
+        assert is_edge_index_list(edge_indices)
+        assert sorted(edge_indices) == [0, 1, 3]
+
     def test_query_edges(self) -> None:
         medrecord = create_medrecord()
 
@@ -2369,6 +2384,15 @@ class TestMedRecord(unittest.TestCase):
             return edge.source_node().index()
 
         assert sorted(medrecord.query_edges(query9)) == ["0", "0", "1", "1"]
+
+        def query10(edge: EdgeOperand) -> List[QueryReturnOperand]:
+            edge.index().equal_to(0)
+            return [edge.index(), edge.source_node().index()]
+
+        edge_indices, node_indices = medrecord.query_edges(query10)
+        assert edge_indices == [0]
+        assert is_node_index_list(node_indices)
+        assert sorted(node_indices) == ["0"]
 
     def test_describe_group_nodes(self) -> None:
         medrecord = create_medrecord()

--- a/tests/medrecord/test_querying.py
+++ b/tests/medrecord/test_querying.py
@@ -677,7 +677,7 @@ class TestNodeMultipleValuesOperand(unittest.TestCase):
 
         assert self.medrecord.query_nodes(query8) == ["pat_10"]
 
-    def test_node_multiple_values_operand_comparisons(self) -> None:  # noqa: C901
+    def test_node_multiple_values_operand_comparisons(self) -> None:
         def query1(node: NodeOperand) -> NodeIndicesOperand:
             node.attribute("age").is_max()
             return node.index()
@@ -770,7 +770,7 @@ class TestNodeMultipleValuesOperand(unittest.TestCase):
             "pat_5",
         ]
 
-    def test_node_multiple_values_operand_operations(self) -> None:  # noqa: C901  # noqa: C901
+    def test_node_multiple_values_operand_operations(self) -> None:
         def query1(node: NodeOperand) -> NodeMultipleValuesOperand:
             query_node(node)
             age = node.attribute("age")
@@ -972,7 +972,7 @@ class TestEdgeMultipleValuesOperand(unittest.TestCase):
             ]
         )
 
-    def test_edge_multiple_values_operand_numeric(self) -> None:  # noqa: C901
+    def test_edge_multiple_values_operand_numeric(self) -> None:
         def query_min(edge: EdgeOperand) -> EdgeSingleValueOperand:
             query_specific_edge(edge, 4)
             attribute = edge.attribute("duration_days")
@@ -1098,7 +1098,7 @@ class TestEdgeMultipleValuesOperand(unittest.TestCase):
 
         assert self.medrecord.query_edges(query8) == [162]
 
-    def test_edge_multiple_values_operand_comparisons(self) -> None:  # noqa: C901
+    def test_edge_multiple_values_operand_comparisons(self) -> None:
         def query1(edge: EdgeOperand) -> EdgeIndicesOperand:
             attribute = edge.attribute("duration_days")
             attribute.is_float()
@@ -1190,7 +1190,7 @@ class TestEdgeMultipleValuesOperand(unittest.TestCase):
 
         assert self.medrecord.query_edges(query13) == [160]
 
-    def test_edge_multiple_values_operand_operations(self) -> None:  # noqa: C901
+    def test_edge_multiple_values_operand_operations(self) -> None:
         def query1(edge: EdgeOperand) -> EdgeMultipleValuesOperand:
             query_specific_edge(edge, 3)
             duration = edge.attribute("duration_days")
@@ -1455,7 +1455,7 @@ class TestNodeSingleValueOperand(unittest.TestCase):
 
         assert self.medrecord.query_nodes(query8) == ["pat_10"]
 
-    def test_node_single_value_operand_comparisons(self) -> None:  # noqa: C901
+    def test_node_single_value_operand_comparisons(self) -> None:
         def query1(node: NodeOperand) -> NodeSingleValueOperand:
             maximum = node.attribute("age").max()
             maximum.greater_than(90)
@@ -1533,7 +1533,7 @@ class TestNodeSingleValueOperand(unittest.TestCase):
 
         assert self.medrecord.query_nodes(query11) == ("pat_3", 96)
 
-    def test_node_single_value_operand_operations(self) -> None:  # noqa: C901
+    def test_node_single_value_operand_operations(self) -> None:
         def query1(node: NodeOperand) -> NodeSingleValueOperand:
             maximum = node.attribute("age").max()
             maximum.add(10)
@@ -1783,7 +1783,7 @@ class TestEdgeSingleValueOperand(unittest.TestCase):
 
         assert self.medrecord.query_edges(query8) == (47, 3416)
 
-    def test_edge_single_value_operand_comparisons(self) -> None:  # noqa: C901
+    def test_edge_single_value_operand_comparisons(self) -> None:
         def query1(edge: EdgeOperand) -> EdgeSingleValueOperand:
             value = edge.attribute("integer_attribute").max()
             value.greater_than(4)
@@ -1861,7 +1861,7 @@ class TestEdgeSingleValueOperand(unittest.TestCase):
 
         assert self.medrecord.query_edges(query11) == (160, " Hello ")
 
-    def test_edge_single_value_operand_operations(self) -> None:  # noqa: C901
+    def test_edge_single_value_operand_operations(self) -> None:
         def query1(edge: EdgeOperand) -> EdgeSingleValueOperand:
             value = edge.attribute("integer_attribute").max()
             value.add(10)
@@ -2042,7 +2042,7 @@ class TestNodeIndicesOperand(unittest.TestCase):
     def setUp(self) -> None:
         self.medrecord = MedRecord.from_simple_example_dataset()
 
-    def test_node_indices_operand_comparisons(self) -> None:  # noqa: C901
+    def test_node_indices_operand_comparisons(self) -> None:
         def query1(node: NodeOperand) -> NodeIndicesOperand:
             node.index().equal_to("pat_1")
             return node.index()
@@ -2161,7 +2161,7 @@ class TestNodeIndicesOperand(unittest.TestCase):
 
         assert self.medrecord.query_nodes(query15) == [0]
 
-    def test_node_indices_operand_operations(self) -> None:  # noqa: C901
+    def test_node_indices_operand_operations(self) -> None:
         self.medrecord.unfreeze_schema()
         self.medrecord.add_nodes((10, {}))
         self.medrecord.add_nodes((11, {}))
@@ -2328,7 +2328,7 @@ class TestNodeIndexOperand(unittest.TestCase):
     def setUp(self) -> None:
         self.medrecord = MedRecord.from_simple_example_dataset()
 
-    def test_node_index_operand_comparisons(self) -> None:  # noqa: C901
+    def test_node_index_operand_comparisons(self) -> None:
         def query1(node: NodeOperand) -> NodeIndexOperand:
             node.in_group("patient")
             maximum = node.index().max()
@@ -2437,7 +2437,7 @@ class TestNodeIndexOperand(unittest.TestCase):
 
         assert self.medrecord.query_nodes(query13) == 1
 
-    def test_node_index_operand_operations(self) -> None:  # noqa: C901
+    def test_node_index_operand_operations(self) -> None:
         self.medrecord.unfreeze_schema()
         self.medrecord.add_nodes((10, {}))
         self.medrecord.add_nodes((11, {}))
@@ -2576,7 +2576,7 @@ class TestEdgeIndicesOperand(unittest.TestCase):
     def setUp(self) -> None:
         self.medrecord = MedRecord.from_simple_example_dataset()
 
-    def test_edge_indices_operand_comparisons(self) -> None:  # noqa: C901
+    def test_edge_indices_operand_comparisons(self) -> None:
         def query1(edge: EdgeOperand) -> EdgeIndicesOperand:
             edge.index().equal_to(0)
             return edge.index()
@@ -2665,7 +2665,7 @@ class TestEdgeIndicesOperand(unittest.TestCase):
 
         assert self.medrecord.query_edges(query13) == [0]
 
-    def test_edge_indices_operand_operations(self) -> None:  # noqa: C901
+    def test_edge_indices_operand_operations(self) -> None:
         def query1(edge: EdgeOperand) -> EdgeIndexOperand:
             edge.index().is_in([10, 11])
             return edge.index().max()
@@ -2764,7 +2764,7 @@ class TestEdgeIndexOperand(unittest.TestCase):
     def setUp(self) -> None:
         self.medrecord = MedRecord.from_simple_example_dataset()
 
-    def test_edge_index_operand_comparisons(self) -> None:  # noqa: C901
+    def test_edge_index_operand_comparisons(self) -> None:
         def query1(edge: EdgeOperand) -> EdgeIndexOperand:
             minimum = edge.index().min()
             minimum.equal_to(0)
@@ -2914,7 +2914,7 @@ class TestNodeAttributesTreeOperand(unittest.TestCase):
     def setUp(self) -> None:
         self.medrecord = MedRecord.from_simple_example_dataset()
 
-    def test_node_attributes_tree_operand_comparisons(self) -> None:  # noqa: C901
+    def test_node_attributes_tree_operand_comparisons(self) -> None:
         def query1(node: NodeOperand) -> NodeMultipleAttributesOperand:
             query_node(node)
             return node.attributes().max()
@@ -3082,7 +3082,7 @@ class TestNodeAttributesTreeOperand(unittest.TestCase):
 
         assert self.medrecord.query_nodes(query20) == {0: [2]}
 
-    def test_node_attributes_tree_operand_operations(self) -> None:  # noqa: C901
+    def test_node_attributes_tree_operand_operations(self) -> None:
         self.medrecord.unfreeze_schema()
         self.medrecord.add_nodes((0, {10: "value1", 11: "value2"}))
 
@@ -3251,7 +3251,7 @@ class TestEdgeAttributesTreeOperand(unittest.TestCase):
             [("pat_4", "pat_1", {"a_attribute": "v5", "b_attribute": "v6"})]
         )  # Edge index 164
 
-    def test_edge_attributes_tree_operand_comparisons(self) -> None:  # noqa: C901
+    def test_edge_attributes_tree_operand_comparisons(self) -> None:
         def query1(edge: EdgeOperand) -> EdgeMultipleAttributesOperand:
             query_specific_edge(edge, 164)
             return edge.attributes().max()
@@ -3415,7 +3415,7 @@ class TestEdgeAttributesTreeOperand(unittest.TestCase):
 
         assert self.medrecord.query_edges(query20) == {160: [2]}
 
-    def test_edge_attributes_tree_operand_operations(self) -> None:  # noqa: C901
+    def test_edge_attributes_tree_operand_operations(self) -> None:
         def query1(edge: EdgeOperand) -> EdgeAttributesTreeOperand:
             query_specific_edge(edge, 161)
             attributes = edge.attributes()
@@ -3564,7 +3564,7 @@ class TestNodeMultipleAttributesOperand(unittest.TestCase):
     def setUp(self) -> None:
         self.medrecord = MedRecord.from_simple_example_dataset()
 
-    def test_node_multiple_attributes_operand_comparisons(self) -> None:  # noqa: C901
+    def test_node_multiple_attributes_operand_comparisons(self) -> None:
         self.medrecord.unfreeze_schema()
         self.medrecord.add_nodes((0, {10: "value1", 11: "value2"}))
         self.medrecord.add_nodes((1, {12: "value3", 13: "value4"}))
@@ -3721,7 +3721,7 @@ class TestNodeMultipleAttributesOperand(unittest.TestCase):
 
         assert self.medrecord.query_nodes(query20) == {"pat_1": "gender"}
 
-    def test_node_multiple_attributes_operand_operations(self) -> None:  # noqa: C901
+    def test_node_multiple_attributes_operand_operations(self) -> None:
         self.medrecord.unfreeze_schema()
         self.medrecord.add_nodes((0, {10: "value1", 11: "value2"}))
         self.medrecord.add_nodes((1, {12: "value3", 13: "value4"}))
@@ -3876,7 +3876,7 @@ class TestEdgeMultipleAttributesOperand(unittest.TestCase):
         self.medrecord.add_edges([("pat_3", "pat_4", {12: "value3", 13: "value4"})])
         self.medrecord.add_edges([("pat_5", "pat_1", {" Hello ": "value5"})])
 
-    def test_edge_multiple_attributes_operand_comparisons(self) -> None:  # noqa: C901
+    def test_edge_multiple_attributes_operand_comparisons(self) -> None:
         def query1(edge: EdgeOperand) -> EdgeSingleAttributeOperand:
             edge.index().is_in([160, 161])
             return edge.attributes().max().max()
@@ -4029,7 +4029,7 @@ class TestEdgeMultipleAttributesOperand(unittest.TestCase):
 
         assert self.medrecord.query_edges(query20) == {0: "time"}
 
-    def test_edge_multiple_attributes_operand_operations(self) -> None:  # noqa: C901
+    def test_edge_multiple_attributes_operand_operations(self) -> None:
         def query1(edge: EdgeOperand) -> EdgeMultipleAttributesOperand:
             edge.index().is_in([160, 161])
             attribute = edge.attributes().max()
@@ -4173,7 +4173,7 @@ class TestNodeSingleAttributeOperand(unittest.TestCase):
     def setUp(self) -> None:
         self.medrecord = MedRecord.from_simple_example_dataset()
 
-    def test_single_attribute_operand_comparisons(self) -> None:  # noqa: C901
+    def test_single_attribute_operand_comparisons(self) -> None:
         self.medrecord.unfreeze_schema()
         self.medrecord.add_nodes((0, {10: "value1", 11: "value2"}))
         self.medrecord.add_nodes((1, {12: "value3", 13: "value4"}))
@@ -4425,7 +4425,7 @@ class TestEdgeSingleAttributeOperand(unittest.TestCase):
         self.medrecord.add_edges([("pat_3", "pat_4", {12: "value3", 13: "value4"})])
         self.medrecord.add_edges([("pat_5", "pat_1", {" Hello ": "value5"})])
 
-    def test_single_attribute_operand_comparisons(self) -> None:  # noqa: C901
+    def test_single_attribute_operand_comparisons(self) -> None:
         self.medrecord.unfreeze_schema()
 
         def query1(edge: EdgeOperand) -> EdgeSingleAttributeOperand:

--- a/tests/medrecord/test_types.py
+++ b/tests/medrecord/test_types.py
@@ -7,12 +7,14 @@ import polars as pl
 from medmodels.medrecord.types import (
     is_attributes,
     is_edge_index,
+    is_edge_index_list,
     is_edge_tuple,
     is_edge_tuple_list,
     is_group,
     is_medrecord_attribute,
     is_medrecord_value,
     is_node_index,
+    is_node_index_list,
     is_node_tuple,
     is_node_tuple_list,
     is_pandas_edge_dataframe_input,
@@ -48,10 +50,23 @@ class TestTypeAssertions(unittest.TestCase):
         assert is_node_index(123)
         assert not is_node_index(12.34)
 
+    def test_is_node_index_list(self) -> None:
+        assert is_node_index_list(["node1", "node2"])
+        assert is_node_index_list([123, 456])
+        assert is_node_index_list(["node1", 123])
+        assert not is_node_index_list("invalid")
+        assert not is_node_index_list([123, 12.34])
+
     def test_is_edge_index(self) -> None:
         assert is_edge_index(123)
         assert not is_edge_index("edge")
         assert not is_edge_index(12.34)
+
+    def test_is_edge_index_list(self) -> None:
+        assert is_edge_index_list([123, 456])
+        assert not is_edge_index_list("invalid")
+        assert not is_edge_index_list([123, "edge"])
+        assert not is_edge_index_list([123, 12.34])
 
     def test_is_group(self) -> None:
         assert is_group("group")


### PR DESCRIPTION
This PR refactors the rust return operand types. It also adds the possibility of returning multiple operands from queries. Getting the concrete return value type for these lists is quite difficult in python, so for new the generic return value type alias is returned and users will have to assert to get the concrete type (issue #404).